### PR TITLE
20260410 #52 홈 진도율을 합격 준비도 readiness 로 대체

### DIFF
--- a/server/PQL-Domain-Submission/build.gradle
+++ b/server/PQL-Domain-Submission/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     api project(':PQL-Common')
     api project(':PQL-Domain-Member')
     api project(':PQL-Domain-Question')
+    api project(':PQL-Domain-Meta')
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ProgressResponse.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ProgressResponse.java
@@ -1,3 +1,14 @@
 package com.passql.submission.dto;
 
-public record ProgressResponse(long solvedCount, double correctRate, int streakDays) {}
+/**
+ * 홈 화면용 사용자 진도 응답.
+ *
+ * 기존 3필드(solvedCount, correctRate, streakDays)는 다른 화면에서 계속 사용되므로 100% 보존한다.
+ * `readiness` 블록은 무한 문제 환경에서 "합격 준비도" 개념으로 산출된 게이지 값이다.
+ */
+public record ProgressResponse(
+    long solvedCount,
+    double correctRate,
+    int streakDays,
+    ReadinessResponse readiness
+) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ProgressSummary.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ProgressSummary.java
@@ -1,3 +1,0 @@
-package com.passql.submission.dto;
-
-public record ProgressSummary(long solvedCount, double correctRate, int streakDays) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ReadinessResponse.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ReadinessResponse.java
@@ -1,5 +1,7 @@
 package com.passql.submission.dto;
 
+import com.passql.submission.readiness.ToneKey;
+
 import java.time.LocalDateTime;
 
 /**
@@ -18,5 +20,5 @@ public record ReadinessResponse(
     int coveredTopicCount,
     int activeTopicCount,
     Integer daysUntilExam,
-    String toneKey
+    ToneKey toneKey
 ) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ReadinessResponse.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/ReadinessResponse.java
@@ -1,0 +1,22 @@
+package com.passql.submission.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 합격 준비도(Readiness) 응답 블록.
+ *
+ * 산식의 3요소(정답률/커버리지/최신성)와 원본 카운트를 투명하게 공개한다.
+ * FE는 (toneKey, scoreBand) 조합으로 카피를 선택한다.
+ */
+public record ReadinessResponse(
+    double score,
+    double accuracy,
+    double coverage,
+    double recency,
+    LocalDateTime lastStudiedAt,
+    int recentAttemptCount,
+    int coveredTopicCount,
+    int activeTopicCount,
+    Integer daysUntilExam,
+    String toneKey
+) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/RecentAttemptProjection.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/RecentAttemptProjection.java
@@ -1,0 +1,15 @@
+package com.passql.submission.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Readiness 계산용 최근 시도 투영.
+ *
+ * 하나의 쿼리로 "정답 여부"와 "시도 시각"을 함께 가져와
+ * Accuracy 계산과 lastStudiedAt 파악을 단일 조회로 처리한다.
+ * (기존엔 MAX(submittedAt) 별도 쿼리가 필요했음)
+ */
+public record RecentAttemptProjection(
+    Boolean isCorrect,
+    LocalDateTime submittedAt
+) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessCalculator.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessCalculator.java
@@ -1,0 +1,83 @@
+package com.passql.submission.readiness;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * 합격 준비도 3요소(정답률 × 커버리지 × 최신성) 순수 계산기.
+ *
+ * 순수 함수에 가깝게 유지해 단위 테스트를 쉽게 한다.
+ * DB / Spring Context 의존 없음 — 입력값을 모아서 서비스가 호출한다.
+ */
+@Component
+public class ReadinessCalculator {
+
+    /**
+     * @param recentCorrectFlags 최근 시도의 isCorrect 리스트 (submittedAt DESC, 상위 RECENT_ATTEMPT_WINDOW개)
+     * @param lastStudiedAt 마지막 시도 일자 (없으면 null)
+     * @param coveredTopicCount 최근 COVERAGE_WINDOW_DAYS일 내 distinct 활성 토픽 수
+     * @param activeTopicCount 활성 토픽 전체 수
+     * @param today KST 기준 "오늘" (테스트 용이성)
+     */
+    public ReadinessResult calculate(
+        List<Boolean> recentCorrectFlags,
+        LocalDate lastStudiedAt,
+        int coveredTopicCount,
+        int activeTopicCount,
+        LocalDate today
+    ) {
+        double accuracy = computeAccuracy(recentCorrectFlags);
+        double coverage = computeCoverage(coveredTopicCount, activeTopicCount);
+        double recency = computeRecency(lastStudiedAt, today);
+
+        double score = round2(accuracy * coverage * recency);
+
+        return new ReadinessResult(
+            score,
+            round2(accuracy),
+            round2(coverage),
+            round2(recency),
+            recentCorrectFlags == null ? 0 : recentCorrectFlags.size()
+        );
+    }
+
+    private double computeAccuracy(List<Boolean> flags) {
+        if (flags == null || flags.isEmpty()) return 0.0;
+        long correct = flags.stream().filter(Boolean.TRUE::equals).count();
+        return (double) correct / flags.size();
+    }
+
+    private double computeCoverage(int covered, int active) {
+        if (active <= 0) return 0.0;
+        return (double) covered / active;
+    }
+
+    private double computeRecency(LocalDate lastStudiedAt, LocalDate today) {
+        if (lastStudiedAt == null) return ReadinessConstants.RECENCY_DEFAULT;
+        long days = ChronoUnit.DAYS.between(lastStudiedAt, today);
+        if (days < 0) days = 0;
+        if (days <= 1) return 1.00;
+        if (days <= 3) return 0.95;
+        if (days <= 7) return 0.85;
+        if (days <= 14) return 0.75;
+        return 0.70;
+    }
+
+    private double round2(double v) {
+        return Math.round(v * 100.0) / 100.0;
+    }
+
+    /**
+     * 계산 결과. ProgressService가 이를 받아 ReadinessResponse로 변환한다.
+     */
+    public record ReadinessResult(
+        double score,
+        double accuracy,
+        double coverage,
+        double recency,
+        int recentAttemptCount
+    ) {}
+}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessCalculator.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessCalculator.java
@@ -1,6 +1,6 @@
 package com.passql.submission.readiness;
 
-import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -9,11 +9,15 @@ import java.util.List;
 /**
  * 합격 준비도 3요소(정답률 × 커버리지 × 최신성) 순수 계산기.
  *
- * 순수 함수에 가깝게 유지해 단위 테스트를 쉽게 한다.
+ * 상태가 없는 순수 함수 묶음이므로 {@code static} 메서드로 노출한다.
+ * 프로젝트 내 다른 순수 유틸(예: {@code StreakCalculator})과 컨벤션 일치.
+ *
  * DB / Spring Context 의존 없음 — 입력값을 모아서 서비스가 호출한다.
  */
-@Component
-public class ReadinessCalculator {
+@Slf4j
+public final class ReadinessCalculator {
+
+    private ReadinessCalculator() {}
 
     /**
      * @param recentCorrectFlags 최근 시도의 isCorrect 리스트 (submittedAt DESC, 상위 RECENT_ATTEMPT_WINDOW개)
@@ -22,7 +26,7 @@ public class ReadinessCalculator {
      * @param activeTopicCount 활성 토픽 전체 수
      * @param today KST 기준 "오늘" (테스트 용이성)
      */
-    public ReadinessResult calculate(
+    public static ReadinessResult calculate(
         List<Boolean> recentCorrectFlags,
         LocalDate lastStudiedAt,
         int coveredTopicCount,
@@ -44,29 +48,36 @@ public class ReadinessCalculator {
         );
     }
 
-    private double computeAccuracy(List<Boolean> flags) {
+    private static double computeAccuracy(List<Boolean> flags) {
         if (flags == null || flags.isEmpty()) return 0.0;
         long correct = flags.stream().filter(Boolean.TRUE::equals).count();
         return (double) correct / flags.size();
     }
 
-    private double computeCoverage(int covered, int active) {
+    private static double computeCoverage(int covered, int active) {
         if (active <= 0) return 0.0;
         return (double) covered / active;
     }
 
-    private double computeRecency(LocalDate lastStudiedAt, LocalDate today) {
+    private static double computeRecency(LocalDate lastStudiedAt, LocalDate today) {
         if (lastStudiedAt == null) return ReadinessConstants.RECENCY_DEFAULT;
+
         long days = ChronoUnit.DAYS.between(lastStudiedAt, today);
-        if (days < 0) days = 0;
-        if (days <= 1) return 1.00;
-        if (days <= 3) return 0.95;
-        if (days <= 7) return 0.85;
-        if (days <= 14) return 0.75;
-        return 0.70;
+        if (days < 0) {
+            // 시계 스큐 / 수동 데이터 이상. 0으로 보정하되 관측을 남긴다.
+            log.warn("lastStudiedAt is in the future — clock skew? lastStudiedAt={}, today={}",
+                lastStudiedAt, today);
+            days = 0;
+        }
+
+        if (days <= ReadinessConstants.RECENCY_T1_DAYS) return ReadinessConstants.RECENCY_T1_VALUE;
+        if (days <= ReadinessConstants.RECENCY_T2_DAYS) return ReadinessConstants.RECENCY_T2_VALUE;
+        if (days <= ReadinessConstants.RECENCY_T3_DAYS) return ReadinessConstants.RECENCY_T3_VALUE;
+        if (days <= ReadinessConstants.RECENCY_T4_DAYS) return ReadinessConstants.RECENCY_T4_VALUE;
+        return ReadinessConstants.RECENCY_DEFAULT;
     }
 
-    private double round2(double v) {
+    private static double round2(double v) {
         return Math.round(v * 100.0) / 100.0;
     }
 

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessConstants.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessConstants.java
@@ -1,5 +1,8 @@
 package com.passql.submission.readiness;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 import java.time.ZoneId;
 
 /**
@@ -13,22 +16,38 @@ public final class ReadinessConstants {
     /** 정답률 계산 시 참조할 최근 시도 개수 */
     public static final int RECENT_ATTEMPT_WINDOW = 50;
 
+    /** Accuracy 조회용 재사용 Pageable (불필요한 객체 생성 방지) */
+    public static final Pageable RECENT_PAGE = PageRequest.of(0, RECENT_ATTEMPT_WINDOW);
+
     /** 커버리지 판정 기준 일수 (최근 N일 내 푼 토픽) */
     public static final int COVERAGE_WINDOW_DAYS = 14;
 
     /** 시도 이력이 전혀 없을 때의 Recency 바닥값 */
     public static final double RECENCY_DEFAULT = 0.70;
 
+    // ────────────────────────────────────────────────────────────
+    // Recency 감쇠 테이블
+    // 감쇠 구간/값 조정은 여기 상수만 수정하면 Calculator가 자동 반영한다.
+    // ────────────────────────────────────────────────────────────
+
+    /** 0~1일 경과: 생생한 학습 */
+    public static final long RECENCY_T1_DAYS = 1L;
+    public static final double RECENCY_T1_VALUE = 1.00;
+
+    /** 2~3일 경과 */
+    public static final long RECENCY_T2_DAYS = 3L;
+    public static final double RECENCY_T2_VALUE = 0.95;
+
+    /** 4~7일 경과 */
+    public static final long RECENCY_T3_DAYS = 7L;
+    public static final double RECENCY_T3_VALUE = 0.85;
+
+    /** 8~14일 경과 */
+    public static final long RECENCY_T4_DAYS = 14L;
+    public static final double RECENCY_T4_VALUE = 0.75;
+
+    /** 15일+ : RECENCY_DEFAULT 적용 */
+
     /** 서버 기준 타임존 — Recency/D-day 계산에 사용 */
     public static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
-
-    // toneKey 상수
-    public static final String TONE_NO_EXAM    = "NO_EXAM";
-    public static final String TONE_ONBOARDING = "ONBOARDING";
-    public static final String TONE_POST_EXAM  = "POST_EXAM";
-    public static final String TONE_TODAY      = "TODAY";
-    public static final String TONE_SPRINT     = "SPRINT";
-    public static final String TONE_PUSH       = "PUSH";
-    public static final String TONE_STEADY     = "STEADY";
-    public static final String TONE_EARLY      = "EARLY";
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessConstants.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ReadinessConstants.java
@@ -1,0 +1,34 @@
+package com.passql.submission.readiness;
+
+import java.time.ZoneId;
+
+/**
+ * 합격 준비도(Readiness) 산식에서 사용하는 튜닝 가능 상수 모음.
+ * 실험/조정 시 이 파일만 수정하면 전체 로직이 일관되게 반영된다.
+ */
+public final class ReadinessConstants {
+
+    private ReadinessConstants() {}
+
+    /** 정답률 계산 시 참조할 최근 시도 개수 */
+    public static final int RECENT_ATTEMPT_WINDOW = 50;
+
+    /** 커버리지 판정 기준 일수 (최근 N일 내 푼 토픽) */
+    public static final int COVERAGE_WINDOW_DAYS = 14;
+
+    /** 시도 이력이 전혀 없을 때의 Recency 바닥값 */
+    public static final double RECENCY_DEFAULT = 0.70;
+
+    /** 서버 기준 타임존 — Recency/D-day 계산에 사용 */
+    public static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    // toneKey 상수
+    public static final String TONE_NO_EXAM    = "NO_EXAM";
+    public static final String TONE_ONBOARDING = "ONBOARDING";
+    public static final String TONE_POST_EXAM  = "POST_EXAM";
+    public static final String TONE_TODAY      = "TODAY";
+    public static final String TONE_SPRINT     = "SPRINT";
+    public static final String TONE_PUSH       = "PUSH";
+    public static final String TONE_STEADY     = "STEADY";
+    public static final String TONE_EARLY      = "EARLY";
+}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKey.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKey.java
@@ -1,0 +1,28 @@
+package com.passql.submission.readiness;
+
+/**
+ * 합격 준비도 응답의 카피 톤 분기 키.
+ *
+ * 카피 문자열 자체는 FE가 관리하고, 백엔드는 "어떤 톤인지"만 내려준다.
+ * FE는 (toneKey, scoreBand) 조합으로 카피 매트릭스를 선택한다.
+ *
+ * 우선순위: NO_EXAM > ONBOARDING > POST_EXAM > TODAY > SPRINT > PUSH > STEADY > EARLY
+ */
+public enum ToneKey {
+    /** 선택된 시험 일정 없음 */
+    NO_EXAM,
+    /** 최근 시도 이력 0건 (첫 진입 또는 장기 이탈 복귀) */
+    ONBOARDING,
+    /** 시험일이 지남 */
+    POST_EXAM,
+    /** 시험 당일 */
+    TODAY,
+    /** D-1 ~ D-6: 막판 스퍼트 */
+    SPRINT,
+    /** D-7 ~ D-14: 가속 구간 */
+    PUSH,
+    /** D-15 ~ D-30: 정석 구간 */
+    STEADY,
+    /** D-31+ : 여유 */
+    EARLY
+}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKeyResolver.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKeyResolver.java
@@ -1,0 +1,33 @@
+package com.passql.submission.readiness;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * D-day와 시도 이력을 바탕으로 카피 톤 키를 결정한다.
+ *
+ * 카피 문자열 자체는 FE가 관리하고, 백엔드는 "어떤 톤인지"만 키로 내려준다.
+ * 규칙은 우선순위 순으로 처음 매칭되는 것을 반환한다.
+ *
+ * 1. daysUntilExam == null         → NO_EXAM
+ * 2. recentAttemptCount == 0       → ONBOARDING
+ * 3. daysUntilExam <  0            → POST_EXAM
+ * 4. daysUntilExam == 0            → TODAY
+ * 5. 1  <= daysUntilExam <  7      → SPRINT
+ * 6. 7  <= daysUntilExam < 15      → PUSH
+ * 7. 15 <= daysUntilExam <= 30     → STEADY
+ * 8. daysUntilExam > 30            → EARLY
+ */
+@Component
+public class ToneKeyResolver {
+
+    public String resolve(Integer daysUntilExam, int recentAttemptCount) {
+        if (daysUntilExam == null) return ReadinessConstants.TONE_NO_EXAM;
+        if (recentAttemptCount == 0) return ReadinessConstants.TONE_ONBOARDING;
+        if (daysUntilExam < 0) return ReadinessConstants.TONE_POST_EXAM;
+        if (daysUntilExam == 0) return ReadinessConstants.TONE_TODAY;
+        if (daysUntilExam < 7) return ReadinessConstants.TONE_SPRINT;
+        if (daysUntilExam < 15) return ReadinessConstants.TONE_PUSH;
+        if (daysUntilExam <= 30) return ReadinessConstants.TONE_STEADY;
+        return ReadinessConstants.TONE_EARLY;
+    }
+}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKeyResolver.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/readiness/ToneKeyResolver.java
@@ -1,7 +1,5 @@
 package com.passql.submission.readiness;
 
-import org.springframework.stereotype.Component;
-
 /**
  * D-day와 시도 이력을 바탕으로 카피 톤 키를 결정한다.
  *
@@ -16,18 +14,21 @@ import org.springframework.stereotype.Component;
  * 6. 7  <= daysUntilExam < 15      → PUSH
  * 7. 15 <= daysUntilExam <= 30     → STEADY
  * 8. daysUntilExam > 30            → EARLY
+ *
+ * 상태 없는 순수 함수이므로 static.
  */
-@Component
-public class ToneKeyResolver {
+public final class ToneKeyResolver {
 
-    public String resolve(Integer daysUntilExam, int recentAttemptCount) {
-        if (daysUntilExam == null) return ReadinessConstants.TONE_NO_EXAM;
-        if (recentAttemptCount == 0) return ReadinessConstants.TONE_ONBOARDING;
-        if (daysUntilExam < 0) return ReadinessConstants.TONE_POST_EXAM;
-        if (daysUntilExam == 0) return ReadinessConstants.TONE_TODAY;
-        if (daysUntilExam < 7) return ReadinessConstants.TONE_SPRINT;
-        if (daysUntilExam < 15) return ReadinessConstants.TONE_PUSH;
-        if (daysUntilExam <= 30) return ReadinessConstants.TONE_STEADY;
-        return ReadinessConstants.TONE_EARLY;
+    private ToneKeyResolver() {}
+
+    public static ToneKey resolve(Integer daysUntilExam, int recentAttemptCount) {
+        if (daysUntilExam == null) return ToneKey.NO_EXAM;
+        if (recentAttemptCount == 0) return ToneKey.ONBOARDING;
+        if (daysUntilExam < 0) return ToneKey.POST_EXAM;
+        if (daysUntilExam == 0) return ToneKey.TODAY;
+        if (daysUntilExam < 7) return ToneKey.SPRINT;
+        if (daysUntilExam < 15) return ToneKey.PUSH;
+        if (daysUntilExam <= 30) return ToneKey.STEADY;
+        return ToneKey.EARLY;
     }
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
@@ -1,5 +1,6 @@
 package com.passql.submission.repository;
 
+import com.passql.submission.dto.RecentAttemptProjection;
 import com.passql.submission.entity.Submission;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,40 +32,44 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
     List<java.sql.Date> findSubmissionDatesByMemberUuid(@Param("memberUuid") UUID memberUuid);
 
     /**
-     * 최근 시도의 isCorrect 플래그 리스트 (submittedAt DESC).
-     * ReadinessCalculator의 Accuracy 계산 입력.
-     * 호출부에서 PageRequest.of(0, RECENT_ATTEMPT_WINDOW)로 상위 N개만 조회한다.
+     * Readiness 계산용 최근 시도 투영 (Accuracy + lastStudiedAt 단일 조회).
+     *
+     * 정렬 안정성: 동시각 tiebreaker로 submissionUuid DESC 추가.
+     * 호출부에서 {@code ReadinessConstants.RECENT_PAGE}로 상위 N개만 가져온다.
+     *
+     * 결과의 첫 원소 submittedAt이 마지막 학습 시각이므로 별도 MAX 쿼리가 불필요.
      */
-    @Query("SELECT s.isCorrect FROM Submission s " +
+    @Query("SELECT new com.passql.submission.dto.RecentAttemptProjection(s.isCorrect, s.submittedAt) " +
+           "FROM Submission s " +
            "WHERE s.memberUuid = :memberUuid " +
-           "ORDER BY s.submittedAt DESC")
-    List<Boolean> findRecentCorrectFlagsByMemberUuid(
+           "ORDER BY s.submittedAt DESC, s.submissionUuid DESC")
+    List<RecentAttemptProjection> findRecentAttemptsByMemberUuid(
         @Param("memberUuid") UUID memberUuid,
         Pageable pageable
     );
 
     /**
      * 최근 :since 이후에 제출된 문제들 중 "활성 토픽"의 distinct 개수.
-     * Submission에는 topicUuid가 없으므로 Question과 join하여 topicUuid를 얻고,
-     * Topic.isActive=true인 것만 센다.
+     *
+     * 네이티브 쿼리로 작성한 이유:
+     *  - Submission 엔티티에 Question/Topic 연관관계(@ManyToOne)가 없어 JPQL theta-join을 쓰면
+     *    파서/옵티마이저 이슈(데카르트 조인 → HashJoin 최적화 실패)가 생길 수 있음
+     *  - JPQL FQN 참조는 부분 컨텍스트 테스트(@DataJpaTest)에서 엔티티 클래스 로딩 순서 의존성을 가짐
+     *  - 기존 {@code calculateCorrectRateByMemberUuid}가 이미 네이티브 쿼리를 쓰고 있어 컨벤션 일관
+     *
      * ReadinessCalculator의 Coverage 분자.
      */
-    @Query("SELECT COUNT(DISTINCT q.topicUuid) " +
-           "FROM Submission s, com.passql.question.entity.Question q, com.passql.meta.entity.Topic t " +
-           "WHERE s.questionUuid = q.questionUuid " +
-           "  AND q.topicUuid = t.topicUuid " +
-           "  AND s.memberUuid = :memberUuid " +
-           "  AND s.submittedAt >= :since " +
-           "  AND t.isActive = true")
+    @Query(value =
+        "SELECT COUNT(DISTINCT q.topic_uuid) " +
+        "FROM submission s " +
+        "JOIN question q ON q.question_uuid = s.question_uuid " +
+        "JOIN topic t ON t.topic_uuid = q.topic_uuid " +
+        "WHERE s.member_uuid = :memberUuid " +
+        "  AND s.submitted_at >= :since " +
+        "  AND t.is_active = 1",
+        nativeQuery = true)
     long countDistinctRecentActiveTopicsByMemberUuid(
-        @Param("memberUuid") UUID memberUuid,
+        @Param("memberUuid") String memberUuid,
         @Param("since") LocalDateTime since
     );
-
-    /**
-     * 사용자의 가장 최근 제출 시각. 미제출 시 null.
-     * Recency 계산 + lastStudiedAt 응답 필드.
-     */
-    @Query("SELECT MAX(s.submittedAt) FROM Submission s WHERE s.memberUuid = :memberUuid")
-    LocalDateTime findLastSubmittedAtByMemberUuid(@Param("memberUuid") UUID memberUuid);
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
@@ -1,6 +1,7 @@
 package com.passql.submission.repository;
 
 import com.passql.submission.entity.Submission;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +29,42 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
 
     @Query("SELECT DISTINCT FUNCTION('DATE', s.submittedAt) FROM Submission s WHERE s.memberUuid = :memberUuid ORDER BY FUNCTION('DATE', s.submittedAt) DESC")
     List<java.sql.Date> findSubmissionDatesByMemberUuid(@Param("memberUuid") UUID memberUuid);
+
+    /**
+     * 최근 시도의 isCorrect 플래그 리스트 (submittedAt DESC).
+     * ReadinessCalculator의 Accuracy 계산 입력.
+     * 호출부에서 PageRequest.of(0, RECENT_ATTEMPT_WINDOW)로 상위 N개만 조회한다.
+     */
+    @Query("SELECT s.isCorrect FROM Submission s " +
+           "WHERE s.memberUuid = :memberUuid " +
+           "ORDER BY s.submittedAt DESC")
+    List<Boolean> findRecentCorrectFlagsByMemberUuid(
+        @Param("memberUuid") UUID memberUuid,
+        Pageable pageable
+    );
+
+    /**
+     * 최근 :since 이후에 제출된 문제들 중 "활성 토픽"의 distinct 개수.
+     * Submission에는 topicUuid가 없으므로 Question과 join하여 topicUuid를 얻고,
+     * Topic.isActive=true인 것만 센다.
+     * ReadinessCalculator의 Coverage 분자.
+     */
+    @Query("SELECT COUNT(DISTINCT q.topicUuid) " +
+           "FROM Submission s, com.passql.question.entity.Question q, com.passql.meta.entity.Topic t " +
+           "WHERE s.questionUuid = q.questionUuid " +
+           "  AND q.topicUuid = t.topicUuid " +
+           "  AND s.memberUuid = :memberUuid " +
+           "  AND s.submittedAt >= :since " +
+           "  AND t.isActive = true")
+    long countDistinctRecentActiveTopicsByMemberUuid(
+        @Param("memberUuid") UUID memberUuid,
+        @Param("since") LocalDateTime since
+    );
+
+    /**
+     * 사용자의 가장 최근 제출 시각. 미제출 시 null.
+     * Recency 계산 + lastStudiedAt 응답 필드.
+     */
+    @Query("SELECT MAX(s.submittedAt) FROM Submission s WHERE s.memberUuid = :memberUuid")
+    LocalDateTime findLastSubmittedAtByMemberUuid(@Param("memberUuid") UUID memberUuid);
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
@@ -3,38 +3,120 @@ package com.passql.submission.service;
 import com.passql.common.exception.CustomException;
 import com.passql.common.exception.constant.ErrorCode;
 import com.passql.member.repository.MemberRepository;
+import com.passql.meta.dto.ExamScheduleResponse;
+import com.passql.meta.repository.TopicRepository;
+import com.passql.meta.service.ExamScheduleService;
 import com.passql.submission.dto.ProgressResponse;
 import com.passql.submission.dto.ProgressSummary;
+import com.passql.submission.dto.ReadinessResponse;
+import com.passql.submission.readiness.ReadinessCalculator;
+import com.passql.submission.readiness.ReadinessConstants;
+import com.passql.submission.readiness.ToneKeyResolver;
 import com.passql.submission.repository.SubmissionRepository;
 import com.passql.submission.util.StreakCalculator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProgressService {
+
     private final SubmissionRepository submissionRepository;
     private final MemberRepository memberRepository;
+    private final TopicRepository topicRepository;
+    private final ExamScheduleService examScheduleService;
+    private final ReadinessCalculator readinessCalculator;
+    private final ToneKeyResolver toneKeyResolver;
 
     public ProgressResponse getProgress(UUID memberUuid) {
         if (!memberRepository.existsByMemberUuidAndIsDeletedFalse(memberUuid)) {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
+
+        // 기존 3지표
         long solvedCount = submissionRepository.countDistinctQuestionUuidByMemberUuid(memberUuid);
         Double rateRaw = submissionRepository.calculateCorrectRateByMemberUuid(memberUuid.toString());
         double correctRate = rateRaw == null ? 0.0 : Math.round(rateRaw * 100.0) / 100.0;
         int streakDays = StreakCalculator.calculate(
             submissionRepository.findSubmissionDatesByMemberUuid(memberUuid)
         );
-        return new ProgressResponse(solvedCount, correctRate, streakDays);
+
+        // Readiness 계산
+        ReadinessResponse readiness = buildReadiness(memberUuid);
+
+        return new ProgressResponse(solvedCount, correctRate, streakDays, readiness);
     }
 
     public ProgressSummary getSummary(UUID memberUuid) {
         ProgressResponse pr = getProgress(memberUuid);
         return new ProgressSummary(pr.solvedCount(), pr.correctRate(), pr.streakDays());
+    }
+
+    private ReadinessResponse buildReadiness(UUID memberUuid) {
+        LocalDate today = LocalDate.now(ReadinessConstants.ZONE);
+
+        // 1. 최근 N개 시도 정답 플래그
+        List<Boolean> recentFlags = submissionRepository.findRecentCorrectFlagsByMemberUuid(
+            memberUuid,
+            PageRequest.of(0, ReadinessConstants.RECENT_ATTEMPT_WINDOW)
+        );
+
+        // 2. 마지막 시도 시각
+        LocalDateTime lastStudiedAt = submissionRepository.findLastSubmittedAtByMemberUuid(memberUuid);
+        LocalDate lastStudiedDate = lastStudiedAt == null
+            ? null
+            : lastStudiedAt.atZone(ReadinessConstants.ZONE).toLocalDate();
+
+        // 3. 활성 토픽 전체 수
+        int activeTopicCount = topicRepository.findByIsActiveTrueOrderBySortOrderAsc().size();
+
+        // 4. 최근 W일 내 푼 활성 토픽 수
+        LocalDateTime since = today
+            .minusDays(ReadinessConstants.COVERAGE_WINDOW_DAYS)
+            .atStartOfDay();
+        long coveredLong = submissionRepository.countDistinctRecentActiveTopicsByMemberUuid(memberUuid, since);
+        int coveredTopicCount = (int) coveredLong;
+
+        // 5. 3요소 계산
+        ReadinessCalculator.ReadinessResult result = readinessCalculator.calculate(
+            recentFlags,
+            lastStudiedDate,
+            coveredTopicCount,
+            activeTopicCount,
+            today
+        );
+
+        // 6. D-day
+        Integer daysUntilExam = null;
+        ExamScheduleResponse selected = examScheduleService.getSelectedSchedule();
+        if (selected != null && selected.getExamDate() != null) {
+            long diff = ChronoUnit.DAYS.between(today, selected.getExamDate());
+            daysUntilExam = (int) diff;
+        }
+
+        // 7. toneKey
+        String toneKey = toneKeyResolver.resolve(daysUntilExam, result.recentAttemptCount());
+
+        return new ReadinessResponse(
+            result.score(),
+            result.accuracy(),
+            result.coverage(),
+            result.recency(),
+            lastStudiedAt,
+            result.recentAttemptCount(),
+            coveredTopicCount,
+            activeTopicCount,
+            daysUntilExam,
+            toneKey
+        );
     }
 }

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
@@ -7,15 +7,15 @@ import com.passql.meta.dto.ExamScheduleResponse;
 import com.passql.meta.repository.TopicRepository;
 import com.passql.meta.service.ExamScheduleService;
 import com.passql.submission.dto.ProgressResponse;
-import com.passql.submission.dto.ProgressSummary;
 import com.passql.submission.dto.ReadinessResponse;
+import com.passql.submission.dto.RecentAttemptProjection;
 import com.passql.submission.readiness.ReadinessCalculator;
 import com.passql.submission.readiness.ReadinessConstants;
+import com.passql.submission.readiness.ToneKey;
 import com.passql.submission.readiness.ToneKeyResolver;
 import com.passql.submission.repository.SubmissionRepository;
 import com.passql.submission.util.StreakCalculator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,15 +34,12 @@ public class ProgressService {
     private final MemberRepository memberRepository;
     private final TopicRepository topicRepository;
     private final ExamScheduleService examScheduleService;
-    private final ReadinessCalculator readinessCalculator;
-    private final ToneKeyResolver toneKeyResolver;
 
     public ProgressResponse getProgress(UUID memberUuid) {
         if (!memberRepository.existsByMemberUuidAndIsDeletedFalse(memberUuid)) {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
-        // 기존 3지표
         long solvedCount = submissionRepository.countDistinctQuestionUuidByMemberUuid(memberUuid);
         Double rateRaw = submissionRepository.calculateCorrectRateByMemberUuid(memberUuid.toString());
         double correctRate = rateRaw == null ? 0.0 : Math.round(rateRaw * 100.0) / 100.0;
@@ -50,44 +47,42 @@ public class ProgressService {
             submissionRepository.findSubmissionDatesByMemberUuid(memberUuid)
         );
 
-        // Readiness 계산
         ReadinessResponse readiness = buildReadiness(memberUuid);
 
         return new ProgressResponse(solvedCount, correctRate, streakDays, readiness);
     }
 
-    public ProgressSummary getSummary(UUID memberUuid) {
-        ProgressResponse pr = getProgress(memberUuid);
-        return new ProgressSummary(pr.solvedCount(), pr.correctRate(), pr.streakDays());
-    }
-
     private ReadinessResponse buildReadiness(UUID memberUuid) {
         LocalDate today = LocalDate.now(ReadinessConstants.ZONE);
 
-        // 1. 최근 N개 시도 정답 플래그
-        List<Boolean> recentFlags = submissionRepository.findRecentCorrectFlagsByMemberUuid(
+        // 최근 N개 시도 (정답 여부 + 시각) — 단일 쿼리
+        List<RecentAttemptProjection> recentAttempts = submissionRepository.findRecentAttemptsByMemberUuid(
             memberUuid,
-            PageRequest.of(0, ReadinessConstants.RECENT_ATTEMPT_WINDOW)
+            ReadinessConstants.RECENT_PAGE
         );
 
-        // 2. 마지막 시도 시각
-        LocalDateTime lastStudiedAt = submissionRepository.findLastSubmittedAtByMemberUuid(memberUuid);
+        List<Boolean> recentFlags = recentAttempts.stream()
+            .map(RecentAttemptProjection::isCorrect)
+            .toList();
+
+        LocalDateTime lastStudiedAt = recentAttempts.isEmpty()
+            ? null
+            : recentAttempts.get(0).submittedAt();
         LocalDate lastStudiedDate = lastStudiedAt == null
             ? null
             : lastStudiedAt.atZone(ReadinessConstants.ZONE).toLocalDate();
 
-        // 3. 활성 토픽 전체 수
         int activeTopicCount = topicRepository.findByIsActiveTrueOrderBySortOrderAsc().size();
 
-        // 4. 최근 W일 내 푼 활성 토픽 수
         LocalDateTime since = today
             .minusDays(ReadinessConstants.COVERAGE_WINDOW_DAYS)
             .atStartOfDay();
-        long coveredLong = submissionRepository.countDistinctRecentActiveTopicsByMemberUuid(memberUuid, since);
+        long coveredLong = submissionRepository.countDistinctRecentActiveTopicsByMemberUuid(
+            memberUuid.toString(), since
+        );
         int coveredTopicCount = (int) coveredLong;
 
-        // 5. 3요소 계산
-        ReadinessCalculator.ReadinessResult result = readinessCalculator.calculate(
+        ReadinessCalculator.ReadinessResult result = ReadinessCalculator.calculate(
             recentFlags,
             lastStudiedDate,
             coveredTopicCount,
@@ -95,7 +90,6 @@ public class ProgressService {
             today
         );
 
-        // 6. D-day
         Integer daysUntilExam = null;
         ExamScheduleResponse selected = examScheduleService.getSelectedSchedule();
         if (selected != null && selected.getExamDate() != null) {
@@ -103,8 +97,7 @@ public class ProgressService {
             daysUntilExam = (int) diff;
         }
 
-        // 7. toneKey
-        String toneKey = toneKeyResolver.resolve(daysUntilExam, result.recentAttemptCount());
+        ToneKey toneKey = ToneKeyResolver.resolve(daysUntilExam, result.recentAttemptCount());
 
         return new ReadinessResponse(
             result.score(),

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressControllerDocs.java
@@ -17,6 +17,7 @@ public interface ProgressControllerDocs {
   @ApiLogs({
       @ApiLog(date = "2026.04.08", author = Author.SUHSAECHAN, issueNumber = 4, description = "진도 요약 조회 API"),
       @ApiLog(date = "2026.04.08", author = Author.SUHSAECHAN, issueNumber = 22, description = "Submission PK 를 UUID 로 재작성. memberUuid(UUID) 기준 집계. 응답 DTO: ProgressResponse{solvedCount, correctRate(0.0~1.0 둘째자리 반올림), streakDays(하루 그레이스)}"),
+      @ApiLog(date = "2026.04.10", author = Author.SUHSAECHAN, issueNumber = 52, description = "합격 준비도(readiness) 블록 응답에 추가 — Accuracy × Coverage × Recency 3요소 곱셈 + D-day 기반 toneKey. 기존 3필드 보존."),
   })
   @Operation(
       summary = "진도 요약 조회",
@@ -30,7 +31,18 @@ public interface ProgressControllerDocs {
           - solvedCount: 푼 문제 수 (distinct questionUuid 기준)
           - correctRate: 정답률 (0.0~1.0, 마지막 시도 기준, 소수 둘째자리 반올림)
           - streakDays: 연속 학습 일수 (하루 그레이스 — 오늘 미제출이어도 어제까지 연속이면 유지)
-          - 제출 이력 0건이면 {0, 0.0, 0}
+          - 제출 이력 0건이면 solvedCount=0, correctRate=0.0, streakDays=0
+
+          ## readiness (합격 준비도 블록)
+          - score: Accuracy × Coverage × Recency (0.0~1.0, 소수 둘째자리)
+          - accuracy: 최근 50시도의 정답률
+          - coverage: 최근 14일 내 푼 활성 토픽 수 / 활성 토픽 전체 수
+          - recency: 마지막 학습일 기반 감쇠 계수 (0.70~1.00)
+          - lastStudiedAt: 마지막 시도 시각 (ISO-8601), 미시도시 null
+          - recentAttemptCount: 최근 50 윈도우 실제 시도 수
+          - coveredTopicCount / activeTopicCount: 커버리지 분자/분모
+          - daysUntilExam: 선택된 시험 일정 기준 D-day (없으면 null)
+          - toneKey: 카피 톤 키 (NO_EXAM / ONBOARDING / POST_EXAM / TODAY / SPRINT / PUSH / STEADY / EARLY)
           """
   )
   ResponseEntity<ProgressResponse> getProgress(


### PR DESCRIPTION
- #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학습 준비도 평가 메트릭을 진도 조회 응답에 추가했습니다. 이제 정확도, 범위, 최근성 점수와 시험 일정까지의 남은 일 수가 포함됩니다.

* **문서화**
  * 준비도 지원을 포함하도록 API 명세를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->