### PR TITLE
날짜별 학습 기록 히트맵 API 요청

### DIFF
--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/HeatmapEntry.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/HeatmapEntry.java
@@ -2,4 +2,8 @@ package com.passql.submission.dto;
 
 import java.time.LocalDate;
 
-public record HeatmapEntry(LocalDate date, int count) {}
+public record HeatmapEntry(
+    LocalDate date,
+    int solvedCount,
+    int correctCount
+) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/HeatmapResponse.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/dto/HeatmapResponse.java
@@ -1,0 +1,7 @@
+package com.passql.submission.dto;
+
+import java.util.List;
+
+public record HeatmapResponse(
+    List<HeatmapEntry> entries
+) {}

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/repository/SubmissionRepository.java
@@ -75,6 +75,31 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
         @Param("since") LocalDateTime since
     );
 
+    /**
+     * 히트맵용 날짜별 풀이/정답 수 집계.
+     *
+     * 기존 인덱스 idx_submission_member_submitted (member_uuid, submitted_at) 활용.
+     * to 파라미터는 exclusive upper bound — Service에서 (to + 1일).atStartOfDay()로 전달.
+     *
+     * @return Object[] = { java.sql.Date date, long solvedCount, long correctCount }
+     */
+    @Query(value =
+        "SELECT DATE(s.submitted_at) AS date, " +
+        "       COUNT(*)              AS solved_count, " +
+        "       SUM(s.is_correct)     AS correct_count " +
+        "FROM submission s " +
+        "WHERE s.member_uuid = :memberUuid " +
+        "  AND s.submitted_at >= :fromDate " +
+        "  AND s.submitted_at < :toDateExclusive " +
+        "GROUP BY DATE(s.submitted_at) " +
+        "ORDER BY date ASC",
+        nativeQuery = true)
+    List<Object[]> findHeatmapByMemberUuid(
+        @Param("memberUuid") String memberUuid,
+        @Param("fromDate") LocalDateTime fromDate,
+        @Param("toDateExclusive") LocalDateTime toDateExclusive
+    );
+
     @Modifying
     @Transactional
     void deleteByQuestionUuid(UUID questionUuid);

--- a/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
+++ b/server/PQL-Domain-Submission/src/main/java/com/passql/submission/service/ProgressService.java
@@ -6,6 +6,8 @@ import com.passql.member.repository.MemberRepository;
 import com.passql.meta.dto.ExamScheduleResponse;
 import com.passql.meta.repository.TopicRepository;
 import com.passql.meta.service.ExamScheduleService;
+import com.passql.submission.dto.HeatmapEntry;
+import com.passql.submission.dto.HeatmapResponse;
 import com.passql.submission.dto.ProgressResponse;
 import com.passql.submission.dto.ReadinessResponse;
 import com.passql.submission.dto.RecentAttemptProjection;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -111,5 +114,36 @@ public class ProgressService {
             daysUntilExam,
             toneKey
         );
+    }
+
+    public HeatmapResponse getHeatmap(UUID memberUuid, LocalDate from, LocalDate to) {
+        if (!memberRepository.existsByMemberUuidAndIsDeletedFalse(memberUuid)) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate effectiveFrom = (from != null) ? from : today.minusDays(30);
+        LocalDate effectiveTo = (to != null) ? to : today;
+
+        if (effectiveFrom.isAfter(effectiveTo)) {
+            return new HeatmapResponse(Collections.emptyList());
+        }
+
+        LocalDateTime fromDateTime = effectiveFrom.atStartOfDay();
+        LocalDateTime toDateTimeExclusive = effectiveTo.plusDays(1).atStartOfDay();
+
+        List<Object[]> rows = submissionRepository.findHeatmapByMemberUuid(
+            memberUuid.toString(), fromDateTime, toDateTimeExclusive
+        );
+
+        List<HeatmapEntry> entries = rows.stream()
+            .map(row -> new HeatmapEntry(
+                ((java.sql.Date) row[0]).toLocalDate(),
+                ((Number) row[1]).intValue(),
+                ((Number) row[2]).intValue()
+            ))
+            .toList();
+
+        return new HeatmapResponse(entries);
     }
 }

--- a/server/PQL-Domain-Submission/src/test/java/com/passql/submission/service/ProgressServiceTest.java
+++ b/server/PQL-Domain-Submission/src/test/java/com/passql/submission/service/ProgressServiceTest.java
@@ -1,0 +1,69 @@
+package com.passql.submission.service;
+
+import com.passql.submission.dto.HeatmapResponse;
+import com.passql.web.PassqlApplication;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static kr.suhsaechan.suhlogger.util.SuhLogger.*;
+
+@SpringBootTest(classes = PassqlApplication.class)
+@ActiveProfiles("dev")
+@Slf4j
+class ProgressServiceTest {
+
+    @Autowired ProgressService progressService;
+
+    @Test
+    @Transactional
+    public void mainTest() {
+        lineLog("테스트시작");
+
+        lineLog(null);
+        timeLog(this::히트맵_조회_테스트);
+        lineLog(null);
+        timeLog(this::히트맵_빈결과_테스트);
+        lineLog(null);
+        timeLog(this::히트맵_기간지정_테스트);
+        lineLog(null);
+
+        lineLog("테스트종료");
+    }
+
+    public void 히트맵_조회_테스트() {
+        lineLog("히트맵 조회 — 기본 파라미터 (from=null, to=null → 최근 30일)");
+        // 실제 DB에 존재하는 memberUuid로 교체 필요
+        UUID memberUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        HeatmapResponse response = progressService.getHeatmap(memberUuid, null, null);
+        superLog(response);
+    }
+
+    public void 히트맵_빈결과_테스트() {
+        lineLog("히트맵 조회 — 데이터 없는 기간");
+        UUID memberUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        HeatmapResponse response = progressService.getHeatmap(
+            memberUuid,
+            LocalDate.of(2020, 1, 1),
+            LocalDate.of(2020, 1, 31)
+        );
+        superLog(response);
+    }
+
+    public void 히트맵_기간지정_테스트() {
+        lineLog("히트맵 조회 — 특정 기간 지정");
+        UUID memberUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        HeatmapResponse response = progressService.getHeatmap(
+            memberUuid,
+            LocalDate.of(2026, 4, 1),
+            LocalDate.of(2026, 4, 10)
+        );
+        superLog(response);
+    }
+}

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressController.java
@@ -1,11 +1,14 @@
 package com.passql.web.controller;
 
+import com.passql.submission.dto.HeatmapResponse;
 import com.passql.submission.dto.ProgressResponse;
 import com.passql.submission.service.ProgressService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @RestController
@@ -20,5 +23,14 @@ public class ProgressController implements ProgressControllerDocs {
         @RequestParam UUID memberUuid
     ) {
         return ResponseEntity.ok(progressService.getProgress(memberUuid));
+    }
+
+    @GetMapping("/heatmap")
+    public ResponseEntity<HeatmapResponse> getHeatmap(
+        @RequestParam UUID memberUuid,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        return ResponseEntity.ok(progressService.getHeatmap(memberUuid, from, to));
     }
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/ProgressControllerDocs.java
@@ -1,14 +1,17 @@
 package com.passql.web.controller;
 
 import com.passql.common.dto.Author;
+import com.passql.submission.dto.HeatmapResponse;
 import com.passql.submission.dto.ProgressResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.suhsaechan.suhapilog.annotation.ApiLog;
 import kr.suhsaechan.suhapilog.annotation.ApiLogs;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Tag(name = "Progress", description = "학습 진도 조회")
@@ -47,5 +50,31 @@ public interface ProgressControllerDocs {
   )
   ResponseEntity<ProgressResponse> getProgress(
       @RequestParam UUID memberUuid
+  );
+
+  @ApiLogs({
+      @ApiLog(date = "2026.04.10", author = Author.SUHSAECHAN, issueNumber = 42, description = "날짜별 학습 기록 히트맵 API 추가 — DATE(submitted_at) 기준 GROUP BY 집계, sparse array 반환"),
+  })
+  @Operation(
+      summary = "날짜별 학습 히트맵 조회",
+      description = """
+          ## 인증(JWT): **불필요** (추후 헤더 전환 예정)
+
+          ## 요청 파라미터
+          - memberUuid (UUID, required): 회원 식별자
+          - from (LocalDate, optional): 조회 시작일 (기본: 30일 전)
+          - to (LocalDate, optional): 조회 종료일 (기본: 오늘)
+
+          ## 반환값 (HeatmapResponse)
+          - entries: 날짜별 학습 기록 배열 (풀이 없는 날짜는 제외)
+            - date: 날짜 (LocalDate)
+            - solvedCount: 해당 날짜 풀이 수
+            - correctCount: 해당 날짜 정답 수
+          """
+  )
+  ResponseEntity<HeatmapResponse> getHeatmap(
+      @RequestParam UUID memberUuid,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
   );
 }


### PR DESCRIPTION
- #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **진척도 히트맵 조회 기능 추가**: 사용자는 지정된 기간 동안의 문제 풀이 활동 현황을 조회할 수 있습니다. 기본값으로 최근 30일 데이터가 제공되며, 선택적으로 조회 기간을 커스터마이징할 수 있습니다. API를 통해 풀이 현황과 정답 수 정보를 별도로 확인 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->