### PR TITLE
fix: 모달 스크롤 잠금 해제 시 이전 overflow 값 복원 #142

### DIFF
--- a/client/src/components/ConfirmModal.tsx
+++ b/client/src/components/ConfirmModal.tsx
@@ -28,10 +28,12 @@ export default function ConfirmModal({
       if (e.key === "Escape") onCancel();
     };
     window.addEventListener("keydown", handleKeyDown);
+    // 이전 overflow 값 저장 후 복원 — 중첩 모달 대응
+    const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "";
+      document.body.style.overflow = prevOverflow;
     };
   }, [isOpen, onCancel]);
 


### PR DESCRIPTION
overflow를 빈 문자열로 초기화하면 중첩 모달 시 잠금이 풀리는 문제 수정
prevOverflow에 저장 후 cleanup에서 복원

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 모달 창의 스크롤 상태 처리 개선 - 모달이 열릴 때 기존 스크롤 상태가 올바르게 보존되고, 닫힐 때 이전 상태로 복원됩니다. 특히 중첩된 모달 사용 시 스크롤 동작이 더욱 안정적입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->