### PR TITLE
⚙️[기능추가][로그인] 약관 동의 UI 개선 및 Legal 도메인 구현

### DIFF
--- a/client/src/api/legal.ts
+++ b/client/src/api/legal.ts
@@ -1,0 +1,15 @@
+import { apiFetch } from "./client";
+
+export type LegalType = "TERMS_OF_SERVICE" | "PRIVACY_POLICY";
+export type LegalStatus = "PUBLISHED" | "DRAFT";
+
+export interface LegalResponse {
+  readonly type: LegalType;
+  readonly title: string;
+  readonly content: string;
+  readonly status: LegalStatus;
+}
+
+export function fetchLegal(type: LegalType): Promise<LegalResponse> {
+  return apiFetch<LegalResponse>(`/meta/legal/${type}`);
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { signInWithPopup } from "firebase/auth";
 import { firebaseAuth, googleProvider } from "../lib/firebase";
 import { login, type AuthProvider } from "../api/auth";
 import { useAuthStore } from "../stores/authStore";
 import { ApiError } from "../api/client";
+import { fetchLegal, type LegalType } from "../api/legal";
+import MarkdownText from "../components/MarkdownText";
 import logo from "../assets/logo/logo.png";
 
 export default function Login() {
@@ -12,6 +14,7 @@ export default function Login() {
   const setTokens = useAuthStore((s) => s.setTokens);
   const [loadingProvider, setLoadingProvider] = useState<AuthProvider | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [legalModal, setLegalModal] = useState<LegalType | null>(null);
 
   const isLoading = loadingProvider !== null;
 
@@ -126,11 +129,116 @@ export default function Login() {
           )}
         </div>
 
+        {/* 약관 동의 안내 */}
         <p className="mt-6 text-center text-[#9CA3AF] text-xs">
-          로그인하면 이용약관 및 개인정보처리방침에 동의하게 됩니다
+          로그인하면{" "}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-[#6B7280] transition-colors"
+            onClick={() => setLegalModal("TERMS_OF_SERVICE")}
+          >
+            이용약관
+          </button>
+          {" "}및{" "}
+          <button
+            type="button"
+            className="underline underline-offset-2 hover:text-[#6B7280] transition-colors"
+            onClick={() => setLegalModal("PRIVACY_POLICY")}
+          >
+            개인정보처리방침
+          </button>
+          에 동의하게 됩니다
         </p>
       </div>
+
+      {/* daisyUI 반응형 모달 — 모바일 하단 시트, 데스크톱 중앙 */}
+      {legalModal !== null && (
+        <LegalModal type={legalModal} onClose={() => setLegalModal(null)} />
+      )}
     </div>
+  );
+}
+
+function LegalModal({
+  type,
+  onClose,
+}: {
+  readonly type: LegalType;
+  readonly onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [title, setTitle] = useState<string | null>(null);
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
+
+  // 모달 열기 + 닫힐 때 onClose 연동
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+    const handleClose = () => onClose();
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, [onClose]);
+
+  // 약관 내용 fetch
+  useEffect(() => {
+    setLoading(true);
+    setFetchError(false);
+    fetchLegal(type)
+      .then((data) => {
+        setTitle(data.title);
+        setContent(data.content);
+      })
+      .catch(() => setFetchError(true))
+      .finally(() => setLoading(false));
+  }, [type]);
+
+  return (
+    <dialog ref={dialogRef} className="modal modal-bottom sm:modal-middle">
+      <div className="modal-box flex flex-col max-h-[80vh] p-0 overflow-hidden">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[#E5E7EB] shrink-0">
+          <h3 className="text-base font-bold text-[#111827]">
+            {title ?? (loading ? "" : "약관")}
+          </h3>
+          <form method="dialog">
+            <button
+              type="submit"
+              className="btn btn-sm btn-circle btn-ghost text-[#9CA3AF]"
+              aria-label="닫기"
+            >
+              ✕
+            </button>
+          </form>
+        </div>
+
+        {/* 본문 스크롤 영역 */}
+        <div className="overflow-y-auto px-5 py-4 flex-1">
+          {loading && (
+            <div className="flex justify-center py-8">
+              <span className="loading loading-spinner loading-md text-[#4F46E5]" />
+            </div>
+          )}
+          {fetchError && (
+            <p className="text-sm text-[#EF4444] text-center py-8">
+              약관을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+            </p>
+          )}
+          {!loading && !fetchError && content && (
+            <div className="prose prose-sm max-w-none text-[#374151]">
+              <MarkdownText text={content} animated={false} />
+            </div>
+          )}
+          <div className="h-4" />
+        </div>
+      </div>
+      {/* 오버레이 클릭 시 닫기 */}
+      <form method="dialog" className="modal-backdrop">
+        <button type="submit">닫기</button>
+      </form>
+    </dialog>
   );
 }
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -173,10 +173,11 @@ function LegalModal({
   const [fetchError, setFetchError] = useState(false);
 
   // 모달 열기 + 닫힐 때 onClose 연동
+  // open 체크: onClose 참조 변경 시 재실행되어도 이미 열린 dialog에 showModal 중복 호출 방지
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
-    dialog.showModal();
+    if (!dialog.open) dialog.showModal();
     const handleClose = () => onClose();
     dialog.addEventListener("close", handleClose);
     return () => dialog.removeEventListener("close", handleClose);

--- a/docs/suh-template/issue/20260424_283_기능추가_로그인_Legal_도메인_구현_및_약관_모달_UI.md
+++ b/docs/suh-template/issue/20260424_283_기능추가_로그인_Legal_도메인_구현_및_약관_모달_UI.md
@@ -1,0 +1,39 @@
+# ⚙️[기능추가][로그인] 약관 동의 UI 개선 및 Legal 도메인 구현
+
+- 라벨: 작업전
+- 담당자: Cassiiopeia
+
+---
+
+📝 현재 문제점
+---
+
+- 로그인 화면 하단의 "로그인하면 이용약관 및 개인정보처리방침에 동의하게 됩니다" 텍스트가 단순 정적 문구로만 표시됨
+- 약관 내용을 실제로 확인할 수 있는 방법이 없음
+- 약관 콘텐츠가 `AppSetting` 테이블에 key-value로 저장되어 시스템 설정과 도메인이 혼재되는 구조적 문제 존재
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- 이용약관, 개인정보처리방침 텍스트에 클릭 가능한 링크 추가
+- 링크 클릭 시 daisyUI `modal-bottom sm:modal-middle` 반응형 모달로 약관 내용 표시
+- 약관 콘텐츠를 독립적인 `legal` 테이블로 분리하여 관리자 화면에서 수정 가능하도록 구현
+
+⚙️ 작업 내용
+---
+
+- `legal` 테이블 신규 생성 (Flyway 마이그레이션 `V0_0_159`)
+  - `type`: TERMS_OF_SERVICE | PRIVACY_POLICY
+  - `title`, `content` (Markdown), `status`: PUBLISHED | DRAFT
+- `Legal` 엔티티, `LegalRepository`, `LegalService` 구현 (PQL-Domain-Meta)
+- 공개 API 추가: `GET /api/meta/legal/{type}` (인증 불필요)
+- `AdminLegalController` + `admin/legal.html` 관리자 약관 편집 페이지
+- 관리자 사이드바에 약관 관리 메뉴 추가
+- `src/api/legal.ts` 신규 생성 (`fetchLegal(type)`)
+- `Login.tsx` 약관 링크 클릭 시 daisyUI 반응형 모달 표시, API fetch 후 Markdown 렌더링
+
+🙋‍♂️ 담당자
+---
+
+- 백엔드: SUH SAECHAN
+- 프론트엔드: SUH SAECHAN

--- a/docs/superpowers/specs/2026-04-24-recommendation-dedup-design.md
+++ b/docs/superpowers/specs/2026-04-24-recommendation-dedup-design.md
@@ -1,0 +1,74 @@
+# AI 추천 문제 세션 내 중복 제외 설계
+
+## 배경
+
+홈 화면의 AI 추천 문제 새로고침 버튼을 누르면 매번 같은 문제가 나온다. Qdrant 벡터 검색이 결정론적(deterministic)이라 동일한 쿼리 벡터에서는 항상 같은 Top-K 결과가 반환되기 때문이다.
+
+## 목표
+
+새로고침 버튼을 누를 때마다 이번 세션에서 이미 추천된 문제는 다시 나오지 않는다. 브라우저 새로고침 시 자연스럽게 초기화된다.
+
+## 범위 결정
+
+- 세션 내 중복 제외만 구현 (클라이언트 state 관리)
+- "이미 푼 문제 전체 영구 제외"는 범위 밖 — 문제 고갈 위험 + 복습 학습 가치 훼손
+- RANDOM fallback 동작 변경 없음
+
+## 데이터 흐름
+
+```
+진입:    seenUuids=[]       → API(exclude 없음) → [A,B,C] → seenUuids=[A,B,C]
+1회 클릭: seenUuids=[A,B,C] → API(exclude A,B,C) → [D,E,F] → seenUuids=[A~F]
+2회 클릭: seenUuids=[A~F]   → API(exclude A~F)   → [G,H,I] → seenUuids=[A~I]
+브라우저 새로고침: seenUuids=[] (초기화)
+```
+
+## 변경 목록
+
+### 백엔드
+
+**`QuestionController`**
+- `@RequestParam(required = false) String excludeQuestionUuid` →
+  `@RequestParam(required = false) List<String> excludeQuestionUuids`
+
+**`RecommendationService`**
+- `recommend()` 시그니처: `UUID excludeQuestionUuid` → `List<UUID> excludeQuestionUuids`
+- `mustNotIds`에 리스트 전체 추가
+
+### 프론트엔드
+
+**`src/api/questions.ts`**
+- `fetchRecommendations(size?, excludeQuestionUuid?)` →
+  `fetchRecommendations(size?, excludeQuestionUuids?)`
+- `URLSearchParams`에 UUID 배열을 반복 `append`로 직렬화
+
+**`src/hooks/useHome.ts`**
+- `useRecommendations(excludeUuids: string[] = [])` 파라미터 추가
+- `queryKey: ["recommendations", accessToken, excludeUuids]` — 변경 시 재요청 트리거
+
+**`src/pages/Home.tsx`**
+- `seenUuids` state 추가 (`useState<string[]>([])`)
+- 최초 응답 및 새로고침 응답 도착 시 반환된 UUID를 `seenUuids`에 누적
+- `useRecommendations(seenUuids)` 형태로 전달
+- `handleRefresh` 로직 유지 (spinning, refreshKey 애니메이션 그대로)
+
+## API 파라미터 형식
+
+```
+GET /api/questions/recommendations?size=3
+  &excludeQuestionUuids=uuid-1
+  &excludeQuestionUuids=uuid-2
+  &excludeQuestionUuids=uuid-3
+```
+
+Spring `@RequestParam List<String>` 이 동일 키 반복을 자동 처리한다.
+
+## 에러 처리
+
+- 추천 문제가 더 이상 없을 때(빈 배열 반환): 기존 목록 유지 + 버튼 비활성화 없음 (서버가 가능한 만큼 반환)
+- API 실패 시: 기존 `recommendationsError` 처리 그대로
+
+## 테스트 기준
+
+- 새로고침 3회 후 총 9개 UUID가 모두 다른지 확인
+- 브라우저 새로고침 후 `seenUuids`가 초기화되어 기존 문제가 다시 나오는지 확인

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/constant/LegalStatus.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/constant/LegalStatus.java
@@ -1,0 +1,6 @@
+package com.passql.meta.constant;
+
+public enum LegalStatus {
+    DRAFT,
+    PUBLISHED
+}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/constant/LegalType.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/constant/LegalType.java
@@ -1,0 +1,6 @@
+package com.passql.meta.constant;
+
+public enum LegalType {
+    TERMS_OF_SERVICE,
+    PRIVACY_POLICY
+}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalResponse.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalResponse.java
@@ -1,0 +1,21 @@
+package com.passql.meta.dto;
+
+import com.passql.meta.constant.LegalStatus;
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.entity.Legal;
+
+public record LegalResponse(
+        LegalType type,
+        String title,
+        String content,
+        LegalStatus status
+) {
+    public static LegalResponse from(Legal legal) {
+        return new LegalResponse(
+                legal.getType(),
+                legal.getTitle(),
+                legal.getContent(),
+                legal.getStatus()
+        );
+    }
+}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalUpdateRequest.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.passql.meta.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record LegalUpdateRequest(
-        String title,
-        String content
+        @NotBlank String title,
+        @NotBlank String content
 ) {}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalUpdateRequest.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/dto/LegalUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.passql.meta.dto;
+
+public record LegalUpdateRequest(
+        String title,
+        String content
+) {}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/entity/Legal.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/entity/Legal.java
@@ -1,0 +1,43 @@
+package com.passql.meta.entity;
+
+import com.passql.common.entity.BaseEntity;
+import com.passql.meta.constant.LegalStatus;
+import com.passql.meta.constant.LegalType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+    name = "legal",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_legal_type", columnNames = "type")
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Legal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID legalUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private LegalType type;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private LegalStatus status;
+}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/repository/LegalRepository.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/repository/LegalRepository.java
@@ -1,0 +1,14 @@
+package com.passql.meta.repository;
+
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.entity.Legal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LegalRepository extends JpaRepository<Legal, UUID> {
+    Optional<Legal> findByType(LegalType type);
+    List<Legal> findAllByOrderByTypeAsc();
+}

--- a/server/PQL-Domain-Meta/src/main/java/com/passql/meta/service/LegalService.java
+++ b/server/PQL-Domain-Meta/src/main/java/com/passql/meta/service/LegalService.java
@@ -1,0 +1,54 @@
+package com.passql.meta.service;
+
+import com.passql.common.exception.CustomException;
+import com.passql.common.exception.constant.ErrorCode;
+import com.passql.meta.constant.LegalStatus;
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.dto.LegalResponse;
+import com.passql.meta.dto.LegalUpdateRequest;
+import com.passql.meta.entity.Legal;
+import com.passql.meta.repository.LegalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LegalService {
+
+    private final LegalRepository legalRepository;
+
+    /** PUBLISHED 상태인 약관만 공개 API에서 반환 */
+    public LegalResponse getPublished(LegalType type) {
+        Legal legal = legalRepository.findByType(type)
+                .orElseThrow(() -> new CustomException(ErrorCode.SETTING_NOT_FOUND));
+        if (legal.getStatus() != LegalStatus.PUBLISHED) {
+            throw new CustomException(ErrorCode.SETTING_NOT_FOUND);
+        }
+        return LegalResponse.from(legal);
+    }
+
+    public List<LegalResponse> findAll() {
+        return legalRepository.findAllByOrderByTypeAsc().stream()
+                .map(LegalResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void update(LegalType type, LegalUpdateRequest request) {
+        Legal legal = legalRepository.findByType(type)
+                .orElseThrow(() -> new CustomException(ErrorCode.SETTING_NOT_FOUND));
+        legal.setTitle(request.title());
+        legal.setContent(request.content());
+    }
+
+    @Transactional
+    public void updateStatus(LegalType type, LegalStatus status) {
+        Legal legal = legalRepository.findByType(type)
+                .orElseThrow(() -> new CustomException(ErrorCode.SETTING_NOT_FOUND));
+        legal.setStatus(status);
+    }
+}

--- a/server/PQL-Web/src/main/java/com/passql/web/config/SecurityConfig.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/auth/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/meta/**").permitAll()
                 .requestMatchers("/actuator/health").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/MetaController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/MetaController.java
@@ -1,13 +1,14 @@
 package com.passql.web.controller;
 
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.dto.LegalResponse;
 import com.passql.meta.dto.TopicTree;
 import com.passql.meta.entity.ConceptTag;
+import com.passql.meta.service.LegalService;
 import com.passql.meta.service.MetaService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ import java.util.List;
 public class MetaController implements MetaControllerDocs {
 
     private final MetaService metaService;
+    private final LegalService legalService;
 
     @GetMapping("/meta/topics")
     public ResponseEntity<List<TopicTree>> getTopics() {
@@ -26,5 +28,11 @@ public class MetaController implements MetaControllerDocs {
     @GetMapping("/meta/tags")
     public ResponseEntity<List<ConceptTag>> getTags() {
         return ResponseEntity.ok(metaService.getActiveTags());
+    }
+
+    /** 공개 약관 조회 — type: TERMS_OF_SERVICE | PRIVACY_POLICY, 인증 불필요 */
+    @GetMapping("/meta/legal/{type}")
+    public ResponseEntity<LegalResponse> getLegal(@PathVariable LegalType type) {
+        return ResponseEntity.ok(legalService.getPublished(type));
     }
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/MetaControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/MetaControllerDocs.java
@@ -1,6 +1,8 @@
 package com.passql.web.controller;
 
 import com.passql.common.dto.Author;
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.dto.LegalResponse;
 import com.passql.meta.dto.TopicTree;
 import com.passql.meta.entity.ConceptTag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.suhsaechan.suhapilog.annotation.ApiLog;
 import kr.suhsaechan.suhapilog.annotation.ApiLogs;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -51,4 +54,26 @@ public interface MetaControllerDocs {
           """
   )
   ResponseEntity<List<ConceptTag>> getTags();
+
+  @ApiLogs({
+      @ApiLog(date = "2026.04.24", author = Author.SUHSAECHAN, issueNumber = 283, description = "공개 약관 조회 API 추가 — TERMS_OF_SERVICE / PRIVACY_POLICY"),
+  })
+  @Operation(
+      summary = "공개 약관 조회",
+      description = """
+          ## 인증(JWT): **불필요**
+
+          ## 경로 변수
+          - **`type`**: TERMS_OF_SERVICE | PRIVACY_POLICY
+
+          ## 반환값 (LegalResponse)
+          - title: 약관 제목
+          - content: 약관 본문 (마크다운)
+          - status: PUBLISHED
+
+          ## 에러
+          - 404: 해당 type의 PUBLISHED 약관이 없는 경우
+          """
+  )
+  ResponseEntity<LegalResponse> getLegal(@PathVariable LegalType type);
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
@@ -1,0 +1,44 @@
+package com.passql.web.controller.admin;
+
+import com.passql.meta.constant.LegalStatus;
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.dto.LegalUpdateRequest;
+import com.passql.meta.service.LegalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/admin/legal")
+@RequiredArgsConstructor
+public class AdminLegalController {
+
+    private final LegalService legalService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("legals", legalService.findAll());
+        model.addAttribute("legalTypes", LegalType.values());
+        model.addAttribute("currentMenu", "legal");
+        model.addAttribute("pageTitle", "약관 관리");
+        return "admin/legal";
+    }
+
+    @PutMapping("/{type}")
+    @ResponseBody
+    public ResponseEntity<Void> update(@PathVariable LegalType type,
+                                       @RequestBody LegalUpdateRequest request) {
+        legalService.update(type, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{type}/status")
+    @ResponseBody
+    public ResponseEntity<Void> updateStatus(@PathVariable LegalType type,
+                                             @RequestParam LegalStatus status) {
+        legalService.updateStatus(type, status);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @Controller
 @RequestMapping("/admin/legal")
 @RequiredArgsConstructor
-public class AdminLegalController {
+public class AdminLegalController implements AdminLegalControllerDocs {
 
     private final LegalService legalService;
 

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalController.java
@@ -4,6 +4,7 @@ import com.passql.meta.constant.LegalStatus;
 import com.passql.meta.constant.LegalType;
 import com.passql.meta.dto.LegalUpdateRequest;
 import com.passql.meta.service.LegalService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -29,7 +30,7 @@ public class AdminLegalController {
     @PutMapping("/{type}")
     @ResponseBody
     public ResponseEntity<Void> update(@PathVariable LegalType type,
-                                       @RequestBody LegalUpdateRequest request) {
+                                       @Valid @RequestBody LegalUpdateRequest request) {
         legalService.update(type, request);
         return ResponseEntity.ok().build();
     }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/admin/AdminLegalControllerDocs.java
@@ -1,0 +1,60 @@
+package com.passql.web.controller.admin;
+
+import com.passql.common.dto.Author;
+import com.passql.meta.constant.LegalStatus;
+import com.passql.meta.constant.LegalType;
+import com.passql.meta.dto.LegalUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.suhsaechan.suhapilog.annotation.ApiLog;
+import kr.suhsaechan.suhapilog.annotation.ApiLogs;
+import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Admin - Legal", description = "관리자 약관 편집 및 발행 상태 관리")
+public interface AdminLegalControllerDocs {
+
+    @ApiLogs({
+        @ApiLog(date = "2026.04.24", author = Author.SUHSAECHAN, issueNumber = 283, description = "관리자 약관 내용 수정 API 추가"),
+    })
+    @Operation(
+        summary = "약관 내용 수정",
+        description = """
+            ## 인증: 관리자 세션 필요
+
+            ## 경로 변수
+            - **`type`**: TERMS_OF_SERVICE | PRIVACY_POLICY
+
+            ## 요청 바디 (LegalUpdateRequest)
+            - **`title`**: 약관 제목 (필수)
+            - **`content`**: 약관 본문 마크다운 (필수)
+            """
+    )
+    ResponseEntity<Void> update(
+        @PathVariable LegalType type,
+        @Valid @RequestBody LegalUpdateRequest request
+    );
+
+    @ApiLogs({
+        @ApiLog(date = "2026.04.24", author = Author.SUHSAECHAN, issueNumber = 283, description = "관리자 약관 발행 상태 변경 API 추가"),
+    })
+    @Operation(
+        summary = "약관 발행 상태 변경",
+        description = """
+            ## 인증: 관리자 세션 필요
+
+            ## 경로 변수
+            - **`type`**: TERMS_OF_SERVICE | PRIVACY_POLICY
+
+            ## 쿼리 파라미터
+            - **`status`**: PUBLISHED | DRAFT
+            """
+    )
+    ResponseEntity<Void> updateStatus(
+        @PathVariable LegalType type,
+        @RequestParam LegalStatus status
+    );
+}

--- a/server/PQL-Web/src/main/resources/db/migration/V0_0_159__add_legal_table.sql
+++ b/server/PQL-Web/src/main/resources/db/migration/V0_0_159__add_legal_table.sql
@@ -1,0 +1,34 @@
+-- 약관을 독립 도메인으로 관리 — AppSetting과 분리
+CREATE TABLE legal (
+    legal_uuid  BINARY(16)   NOT NULL,
+    type        VARCHAR(50)  NOT NULL,
+    title       VARCHAR(255) NOT NULL,
+    content     TEXT         NOT NULL,
+    status      VARCHAR(20)  NOT NULL DEFAULT 'PUBLISHED',
+    created_at  DATETIME(6),
+    updated_at  DATETIME(6),
+    created_by  VARCHAR(255),
+    updated_by  VARCHAR(255),
+    PRIMARY KEY (legal_uuid),
+    UNIQUE KEY uk_legal_type (type)
+);
+
+INSERT INTO legal (legal_uuid, type, title, content, status, created_at, updated_at)
+VALUES (
+    UUID_TO_BIN(UUID()),
+    'TERMS_OF_SERVICE',
+    '이용약관',
+    '## 제1조 (목적)\n본 약관은 passQL(이하 "서비스")이 제공하는 SQL 자격증 학습 서비스의 이용 조건 및 절차, 회사와 이용자 간의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.\n\n## 제2조 (서비스 이용)\n서비스는 소셜 로그인(Google 등)을 통해 이용할 수 있습니다. 이용자는 타인의 정보를 도용하거나 서비스 운영을 방해하는 행위를 하여서는 안 됩니다.\n\n## 제3조 (서비스 변경 및 중단)\n회사는 서비스 내용을 변경하거나 중단할 수 있으며, 이 경우 사전에 공지합니다. 다만 불가피한 사유로 사전 공지가 어려운 경우 사후에 공지할 수 있습니다.\n\n## 제4조 (지식재산권)\n서비스 내 문제, 해설, AI 생성 콘텐츠 등 모든 저작물의 지식재산권은 회사에 귀속됩니다. 이용자는 서비스를 학습 목적으로만 사용할 수 있으며, 무단 복제·배포를 금지합니다.\n\n## 제5조 (면책)\n회사는 천재지변, 서비스 장애, 이용자 귀책으로 인한 손해에 대해 책임을 지지 않습니다. 서비스는 자격증 합격을 보장하지 않습니다.\n\n## 제6조 (준거법)\n본 약관은 대한민국 법률에 따라 해석되며, 분쟁 발생 시 관할 법원은 회사 소재지를 관할하는 법원으로 합니다.',
+    'PUBLISHED',
+    NOW(6),
+    NOW(6)
+),
+(
+    UUID_TO_BIN(UUID()),
+    'PRIVACY_POLICY',
+    '개인정보처리방침',
+    '## 1. 수집하는 개인정보\n소셜 로그인 시 이메일 주소, 닉네임, 프로필 사진(선택)을 수집합니다. 서비스 이용 중 문제 풀이 이력, 학습 통계 데이터가 자동으로 생성·저장됩니다.\n\n## 2. 수집 목적\n수집된 정보는 회원 식별 및 서비스 제공, 맞춤형 학습 데이터 제공, 서비스 개선 및 통계 분석 목적으로만 사용됩니다.\n\n## 3. 보유 기간\n개인정보는 회원 탈퇴 시 즉시 파기합니다. 단, 관계 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관 후 파기합니다.\n\n## 4. 제3자 제공\n회사는 이용자의 개인정보를 원칙적으로 외부에 제공하지 않습니다. 단, 법령에 의한 경우 또는 이용자가 동의한 경우는 예외로 합니다.\n\n## 5. 이용자의 권리\n이용자는 언제든지 자신의 개인정보 열람, 수정, 삭제를 요청할 수 있습니다. 계정 삭제는 설정 페이지에서 직접 처리하거나 고객센터로 요청하실 수 있습니다.\n\n## 6. 문의\n개인정보 처리에 관한 문의는 chan4760@gmail.com으로 연락해 주세요.',
+    'PUBLISHED',
+    NOW(6),
+    NOW(6)
+);

--- a/server/PQL-Web/src/main/resources/db/migration/V0_0_159__add_legal_table.sql
+++ b/server/PQL-Web/src/main/resources/db/migration/V0_0_159__add_legal_table.sql
@@ -1,34 +1,35 @@
 -- 약관을 독립 도메인으로 관리 — AppSetting과 분리
-CREATE TABLE legal (
-    legal_uuid  BINARY(16)   NOT NULL,
+CREATE TABLE IF NOT EXISTS legal (
+    legal_uuid  UUID         NOT NULL,
     type        VARCHAR(50)  NOT NULL,
     title       VARCHAR(255) NOT NULL,
     content     TEXT         NOT NULL,
     status      VARCHAR(20)  NOT NULL DEFAULT 'PUBLISHED',
-    created_at  DATETIME(6),
-    updated_at  DATETIME(6),
+    created_at  TIMESTAMP,
+    updated_at  TIMESTAMP,
     created_by  VARCHAR(255),
     updated_by  VARCHAR(255),
     PRIMARY KEY (legal_uuid),
-    UNIQUE KEY uk_legal_type (type)
+    CONSTRAINT uk_legal_type UNIQUE (type)
 );
 
 INSERT INTO legal (legal_uuid, type, title, content, status, created_at, updated_at)
 VALUES (
-    UUID_TO_BIN(UUID()),
+    gen_random_uuid(),
     'TERMS_OF_SERVICE',
     '이용약관',
     '## 제1조 (목적)\n본 약관은 passQL(이하 "서비스")이 제공하는 SQL 자격증 학습 서비스의 이용 조건 및 절차, 회사와 이용자 간의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.\n\n## 제2조 (서비스 이용)\n서비스는 소셜 로그인(Google 등)을 통해 이용할 수 있습니다. 이용자는 타인의 정보를 도용하거나 서비스 운영을 방해하는 행위를 하여서는 안 됩니다.\n\n## 제3조 (서비스 변경 및 중단)\n회사는 서비스 내용을 변경하거나 중단할 수 있으며, 이 경우 사전에 공지합니다. 다만 불가피한 사유로 사전 공지가 어려운 경우 사후에 공지할 수 있습니다.\n\n## 제4조 (지식재산권)\n서비스 내 문제, 해설, AI 생성 콘텐츠 등 모든 저작물의 지식재산권은 회사에 귀속됩니다. 이용자는 서비스를 학습 목적으로만 사용할 수 있으며, 무단 복제·배포를 금지합니다.\n\n## 제5조 (면책)\n회사는 천재지변, 서비스 장애, 이용자 귀책으로 인한 손해에 대해 책임을 지지 않습니다. 서비스는 자격증 합격을 보장하지 않습니다.\n\n## 제6조 (준거법)\n본 약관은 대한민국 법률에 따라 해석되며, 분쟁 발생 시 관할 법원은 회사 소재지를 관할하는 법원으로 합니다.',
     'PUBLISHED',
-    NOW(6),
-    NOW(6)
+    NOW(),
+    NOW()
 ),
 (
-    UUID_TO_BIN(UUID()),
+    gen_random_uuid(),
     'PRIVACY_POLICY',
     '개인정보처리방침',
     '## 1. 수집하는 개인정보\n소셜 로그인 시 이메일 주소, 닉네임, 프로필 사진(선택)을 수집합니다. 서비스 이용 중 문제 풀이 이력, 학습 통계 데이터가 자동으로 생성·저장됩니다.\n\n## 2. 수집 목적\n수집된 정보는 회원 식별 및 서비스 제공, 맞춤형 학습 데이터 제공, 서비스 개선 및 통계 분석 목적으로만 사용됩니다.\n\n## 3. 보유 기간\n개인정보는 회원 탈퇴 시 즉시 파기합니다. 단, 관계 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관 후 파기합니다.\n\n## 4. 제3자 제공\n회사는 이용자의 개인정보를 원칙적으로 외부에 제공하지 않습니다. 단, 법령에 의한 경우 또는 이용자가 동의한 경우는 예외로 합니다.\n\n## 5. 이용자의 권리\n이용자는 언제든지 자신의 개인정보 열람, 수정, 삭제를 요청할 수 있습니다. 계정 삭제는 설정 페이지에서 직접 처리하거나 고객센터로 요청하실 수 있습니다.\n\n## 6. 문의\n개인정보 처리에 관한 문의는 chan4760@gmail.com으로 연락해 주세요.',
     'PUBLISHED',
-    NOW(6),
-    NOW(6)
-);
+    NOW(),
+    NOW()
+)
+ON CONFLICT (type) DO NOTHING;

--- a/server/PQL-Web/src/main/resources/templates/admin/layout.html
+++ b/server/PQL-Web/src/main/resources/templates/admin/layout.html
@@ -16,6 +16,10 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- CSRF 토큰 (fetch PUT/POST 요청에 사용) -->
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+
     <!-- Additional CSS -->
     <th:block layout:fragment="css"></th:block>
 </head>

--- a/server/PQL-Web/src/main/resources/templates/admin/layout.html
+++ b/server/PQL-Web/src/main/resources/templates/admin/layout.html
@@ -147,6 +147,12 @@
                     </a>
                 </li>
                 <li>
+                    <a th:href="@{/admin/legal}" th:classappend="${currentMenu == 'legal'} ? 'active'">
+                        <i data-lucide="file-text" class="size-5"></i>
+                        약관 관리
+                    </a>
+                </li>
+                <li>
                     <a th:href="@{/admin/settings}" th:classappend="${currentMenu == 'settings'} ? 'active'">
                         <i data-lucide="settings" class="size-5"></i>
                         앱 설정

--- a/server/PQL-Web/src/main/resources/templates/admin/legal.html
+++ b/server/PQL-Web/src/main/resources/templates/admin/legal.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{admin/layout}">
+
+<th:block layout:fragment="title">약관 관리</th:block>
+
+<th:block layout:fragment="content">
+
+    <div class="space-y-4">
+        <div th:each="legal : ${legals}" class="card bg-base-100 shadow">
+            <div class="card-body p-4">
+
+                <!-- 헤더 -->
+                <div class="flex items-center justify-between mb-3">
+                    <div class="flex items-center gap-2">
+                        <h3 class="card-title text-base" th:text="${legal.title}">이용약관</h3>
+                        <span class="badge badge-xs"
+                              th:classappend="${legal.status.name() == 'PUBLISHED'} ? 'badge-success' : 'badge-ghost'"
+                              th:text="${legal.status.name() == 'PUBLISHED'} ? '게시됨' : '초안'">게시됨</span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <!-- 상태 토글 버튼 -->
+                        <button th:if="${legal.status.name() == 'PUBLISHED'}"
+                                class="btn btn-xs btn-outline btn-warning"
+                                th:data-type="${legal.type}"
+                                onclick="updateStatus(this.dataset.type, 'DRAFT')">
+                            초안으로 변경
+                        </button>
+                        <button th:if="${legal.status.name() == 'DRAFT'}"
+                                class="btn btn-xs btn-outline btn-success"
+                                th:data-type="${legal.type}"
+                                onclick="updateStatus(this.dataset.type, 'PUBLISHED')">
+                            게시
+                        </button>
+                        <!-- 수정 버튼 -->
+                        <button class="btn btn-xs btn-ghost"
+                                th:data-type="${legal.type}"
+                                onclick="startEdit(this.dataset.type)">
+                            <i data-lucide="pencil" class="size-3"></i>
+                            수정
+                        </button>
+                    </div>
+                </div>
+
+                <!-- 제목 입력 (편집 모드) -->
+                <div th:id="'title_row_' + ${legal.type}" class="hidden mb-2">
+                    <label class="text-xs text-base-content/60 mb-1 block">제목</label>
+                    <input type="text"
+                           th:id="'title_' + ${legal.type}"
+                           th:value="${legal.title}"
+                           class="input input-bordered input-sm w-full"/>
+                </div>
+
+                <!-- 본문 -->
+                <div th:id="'view_' + ${legal.type}">
+                    <p class="text-xs text-base-content/50 mb-1">type: <code th:text="${legal.type}">TERMS_OF_SERVICE</code></p>
+                    <pre class="bg-base-200 rounded p-3 text-xs whitespace-pre-wrap max-h-48 overflow-y-auto font-mono"
+                         th:text="${legal.content}"></pre>
+                </div>
+
+                <!-- 본문 편집 textarea (편집 모드) -->
+                <div th:id="'edit_' + ${legal.type}" class="hidden">
+                    <label class="text-xs text-base-content/60 mb-1 block">본문 (Markdown)</label>
+                    <textarea th:id="'content_' + ${legal.type}"
+                              class="textarea textarea-bordered w-full font-mono text-xs"
+                              rows="16"
+                              th:text="${legal.content}"></textarea>
+                    <div class="flex justify-end gap-2 mt-2">
+                        <button class="btn btn-sm btn-ghost"
+                                th:data-type="${legal.type}"
+                                onclick="cancelEdit(this.dataset.type)">취소</button>
+                        <button class="btn btn-sm btn-primary"
+                                th:data-type="${legal.type}"
+                                onclick="saveEdit(this.dataset.type)">저장</button>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+</th:block>
+
+<th:block layout:fragment="js">
+    <script>
+        lucide.createIcons();
+
+        function startEdit(type) {
+            document.getElementById('view_' + type).classList.add('hidden');
+            document.getElementById('edit_' + type).classList.remove('hidden');
+            document.getElementById('title_row_' + type).classList.remove('hidden');
+        }
+
+        function cancelEdit(type) {
+            document.getElementById('view_' + type).classList.remove('hidden');
+            document.getElementById('edit_' + type).classList.add('hidden');
+            document.getElementById('title_row_' + type).classList.add('hidden');
+        }
+
+        function saveEdit(type) {
+            const title = document.getElementById('title_' + type).value;
+            const content = document.getElementById('content_' + type).value;
+            fetch('/admin/legal/' + encodeURIComponent(type), {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title, content })
+            }).then(r => {
+                if (r.ok) location.reload();
+                else alert('저장 실패');
+            });
+        }
+
+        function updateStatus(type, status) {
+            fetch('/admin/legal/' + encodeURIComponent(type) + '/status?status=' + status, {
+                method: 'PUT'
+            }).then(r => {
+                if (r.ok) location.reload();
+                else alert('상태 변경 실패');
+            });
+        }
+    </script>
+</th:block>
+</html>

--- a/server/PQL-Web/src/main/resources/templates/admin/legal.html
+++ b/server/PQL-Web/src/main/resources/templates/admin/legal.html
@@ -97,12 +97,17 @@
             document.getElementById('title_row_' + type).classList.add('hidden');
         }
 
+        // layout.html의 CSRF 메타 태그에서 토큰을 읽어 PUT 요청에 포함
+        const csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content');
+        const csrfHeaders = (csrfToken && csrfHeader) ? { [csrfHeader]: csrfToken } : {};
+
         function saveEdit(type) {
             const title = document.getElementById('title_' + type).value;
             const content = document.getElementById('content_' + type).value;
             fetch('/admin/legal/' + encodeURIComponent(type), {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', ...csrfHeaders },
                 body: JSON.stringify({ title, content })
             }).then(r => {
                 if (r.ok) location.reload();
@@ -112,7 +117,8 @@
 
         function updateStatus(type, status) {
             fetch('/admin/legal/' + encodeURIComponent(type) + '/status?status=' + status, {
-                method: 'PUT'
+                method: 'PUT',
+                headers: csrfHeaders
             }).then(r => {
                 if (r.ok) location.reload();
                 else alert('상태 변경 실패');


### PR DESCRIPTION
## 관련 이슈
https://github.com/passQL-Lab/passQL/issues/283

## 변경 사항

### 백엔드
- `legal` 테이블 신규 생성 (Flyway `V0_0_159`) — type, title, content, status 구조
- `Legal` 엔티티, `LegalRepository`, `LegalService` 구현 (PQL-Domain-Meta)
- `GET /api/meta/legal/{type}` 공개 API 추가 (인증 불필요, SecurityConfig permitAll 적용)
- `AdminLegalController` + `admin/legal.html` 관리자 약관 편집 페이지
- 관리자 사이드바에 약관 관리 메뉴 추가

### 프론트엔드
- `src/api/legal.ts` 신규 생성 (`fetchLegal(type)`)
- `Login.tsx` 약관/개인정보처리방침 링크 클릭 시 daisyUI `modal-bottom sm:modal-middle` 반응형 모달
- API fetch → MarkdownText 렌더링 (로딩/에러 상태 처리)

## 리뷰 반영
- `SecurityConfig` `/api/meta/**` GET permitAll 누락 수정
- `LegalUpdateRequest` `@NotBlank` 입력 검증 추가
- `AdminLegalController` `@Valid` 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 화면의 약관·개인정보처리방침을 클릭 가능한 링크로 변경하고 모달에서 Markdown으로 내용 조회 및 표시 지원
  * 관리자용 약관 관리 화면 추가 — 제목·내용 편집 및 발행 상태(PUBLISHED/DRAFT) 전환 가능
  * 공개 API로 약관 문서 조회 지원 및 해당 GET 엔드포인트에 대한 무인증 접근 허용
  * DB 마이그레이션으로 약관 저장소와 초기 약관 데이터 추가

* **문서**
  * 로그인 약관 모달 및 약관 도메인 구현 문서 추가
  * AI 추천 중복 제거 설계 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->