### PR TITLE
🚀[기능개선][홈] AI 추천 문제 새로고침 세션 내 중복 제외

### DIFF
--- a/client/src/api/questions.ts
+++ b/client/src/api/questions.ts
@@ -47,11 +47,12 @@ export function fetchTodayQuestion(): Promise<TodayQuestionResponse> {
 
 export function fetchRecommendations(
   size?: number,
-  excludeQuestionUuid?: string,
+  excludeQuestionUuids?: string[],
 ): Promise<RecommendationsResponse> {
   const query = new URLSearchParams();
   if (size != null) query.set("size", String(size));
-  if (excludeQuestionUuid) query.set("excludeQuestionUuid", excludeQuestionUuid);
+  // 동일 키 반복 append — Spring @RequestParam List<String> 자동 처리
+  excludeQuestionUuids?.forEach((uuid) => query.append("excludeQuestionUuids", uuid));
   const qs = query.toString();
   return apiFetch(`/questions/recommendations${qs ? `?${qs}` : ""}`);
 }

--- a/client/src/hooks/useHome.ts
+++ b/client/src/hooks/useHome.ts
@@ -27,11 +27,12 @@ export function useTodayQuestion() {
   });
 }
 
-export function useRecommendations() {
+export function useRecommendations(excludeUuids: string[] = []) {
   const accessToken = useAuthStore((s) => s.accessToken);
   return useQuery({
-    queryKey: ["recommendations", accessToken],
-    queryFn: () => fetchRecommendations(3),
+    // excludeUuids가 바뀌면 새 요청 트리거 — 세션 내 중복 제외 핵심
+    queryKey: ["recommendations", accessToken, excludeUuids],
+    queryFn: () => fetchRecommendations(3, excludeUuids),
     staleTime: 1000 * 60 * 5,
     retry: false,
   });

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { Flame, ChevronRight, Check, RefreshCw, Sparkles } from "lucide-react";
 import { getReadinessCopy } from "../constants/readinessCopy";
 import { Link } from "react-router-dom";
-import { useState, useCallback, type CSSProperties } from "react";
+import { useState, useCallback, useEffect, type CSSProperties } from "react";
 import { useProgress } from "../hooks/useProgress";
 import { useMember } from "../hooks/useMember";
 import { useAuthStore } from "../stores/authStore";
@@ -56,12 +56,30 @@ export default function Home() {
   useMember();
   const { data: greeting } = useGreeting();
   const { data: today } = useTodayQuestion();
+  // 버튼 1회전 트리거 — 애니메이션 클래스를 뗐다 붙이기 위해 별도 state 사용
+  const [spinning, setSpinning] = useState(false);
+  // 카드 페이드인 재트리거 — key가 바뀌면 카드 목록이 재마운트되어 애니메이션 재실행
+  const [refreshKey, setRefreshKey] = useState(0);
+  // 세션 내 이미 추천된 UUID 누적 — 새로고침 시 제외 목록으로 전달
+  const [seenUuids, setSeenUuids] = useState<string[]>([]);
+
   const {
     data: recommendations,
     isError: recommendationsError,
     refetch: refetchRecommendations,
     isFetching: recommendationsFetching,
-  } = useRecommendations();
+  } = useRecommendations(seenUuids);
+  // 추천 결과가 도착하면 해당 UUID를 seenUuids에 누적
+  useEffect(() => {
+    if (recommendations?.questions && recommendations.questions.length > 0) {
+      setSeenUuids((prev) => {
+        const newUuids = recommendations.questions
+          .map((q) => q.questionUuid)
+          .filter((uuid) => !prev.includes(uuid));
+        return newUuids.length > 0 ? [...prev, ...newUuids] : prev;
+      });
+    }
+  }, [recommendations]);
   const { data: schedule } = useSelectedSchedule();
   const {
     data: heatmap,
@@ -69,11 +87,6 @@ export default function Home() {
     isError: heatmapError,
     refetch: refetchHeatmap,
   } = useHeatmap();
-
-  // 버튼 1회전 트리거 — 애니메이션 클래스를 뗐다 붙이기 위해 별도 state 사용
-  const [spinning, setSpinning] = useState(false);
-  // 카드 페이드인 재트리거 — key가 바뀌면 카드 목록이 재마운트되어 애니메이션 재실행
-  const [refreshKey, setRefreshKey] = useState(0);
 
   const handleRefresh = useCallback(() => {
     if (recommendationsFetching || spinning) return;

--- a/docs/superpowers/specs/2026-04-24-recommendation-dedup-design.md
+++ b/docs/superpowers/specs/2026-04-24-recommendation-dedup-design.md
@@ -1,0 +1,74 @@
+# AI 추천 문제 세션 내 중복 제외 설계
+
+## 배경
+
+홈 화면의 AI 추천 문제 새로고침 버튼을 누르면 매번 같은 문제가 나온다. Qdrant 벡터 검색이 결정론적(deterministic)이라 동일한 쿼리 벡터에서는 항상 같은 Top-K 결과가 반환되기 때문이다.
+
+## 목표
+
+새로고침 버튼을 누를 때마다 이번 세션에서 이미 추천된 문제는 다시 나오지 않는다. 브라우저 새로고침 시 자연스럽게 초기화된다.
+
+## 범위 결정
+
+- 세션 내 중복 제외만 구현 (클라이언트 state 관리)
+- "이미 푼 문제 전체 영구 제외"는 범위 밖 — 문제 고갈 위험 + 복습 학습 가치 훼손
+- RANDOM fallback 동작 변경 없음
+
+## 데이터 흐름
+
+```
+진입:    seenUuids=[]       → API(exclude 없음) → [A,B,C] → seenUuids=[A,B,C]
+1회 클릭: seenUuids=[A,B,C] → API(exclude A,B,C) → [D,E,F] → seenUuids=[A~F]
+2회 클릭: seenUuids=[A~F]   → API(exclude A~F)   → [G,H,I] → seenUuids=[A~I]
+브라우저 새로고침: seenUuids=[] (초기화)
+```
+
+## 변경 목록
+
+### 백엔드
+
+**`QuestionController`**
+- `@RequestParam(required = false) String excludeQuestionUuid` →
+  `@RequestParam(required = false) List<String> excludeQuestionUuids`
+
+**`RecommendationService`**
+- `recommend()` 시그니처: `UUID excludeQuestionUuid` → `List<UUID> excludeQuestionUuids`
+- `mustNotIds`에 리스트 전체 추가
+
+### 프론트엔드
+
+**`src/api/questions.ts`**
+- `fetchRecommendations(size?, excludeQuestionUuid?)` →
+  `fetchRecommendations(size?, excludeQuestionUuids?)`
+- `URLSearchParams`에 UUID 배열을 반복 `append`로 직렬화
+
+**`src/hooks/useHome.ts`**
+- `useRecommendations(excludeUuids: string[] = [])` 파라미터 추가
+- `queryKey: ["recommendations", accessToken, excludeUuids]` — 변경 시 재요청 트리거
+
+**`src/pages/Home.tsx`**
+- `seenUuids` state 추가 (`useState<string[]>([])`)
+- 최초 응답 및 새로고침 응답 도착 시 반환된 UUID를 `seenUuids`에 누적
+- `useRecommendations(seenUuids)` 형태로 전달
+- `handleRefresh` 로직 유지 (spinning, refreshKey 애니메이션 그대로)
+
+## API 파라미터 형식
+
+```
+GET /api/questions/recommendations?size=3
+  &excludeQuestionUuids=uuid-1
+  &excludeQuestionUuids=uuid-2
+  &excludeQuestionUuids=uuid-3
+```
+
+Spring `@RequestParam List<String>` 이 동일 키 반복을 자동 처리한다.
+
+## 에러 처리
+
+- 추천 문제가 더 이상 없을 때(빈 배열 반환): 기존 목록 유지 + 버튼 비활성화 없음 (서버가 가능한 만큼 반환)
+- API 실패 시: 기존 `recommendationsError` 처리 그대로
+
+## 테스트 기준
+
+- 새로고침 3회 후 총 9개 UUID가 모두 다른지 확인
+- 브라우저 새로고침 후 `seenUuids`가 초기화되어 기존 문제가 다시 나오는지 확인

--- a/server/PQL-Application/src/main/java/com/passql/application/service/RecommendationService.java
+++ b/server/PQL-Application/src/main/java/com/passql/application/service/RecommendationService.java
@@ -43,22 +43,22 @@ public class RecommendationService {
      *
      * memberUuid가 있으면 RAG 기반 추천을 시도하고, 실패하거나 결과가 없으면 RANDOM fallback.
      *
-     * @param size              추천 문제 수 (1~5)
-     * @param excludeQuestionUuid 제외할 문제 UUID (오늘의 문제 등)
-     * @param memberUuid        회원 UUID (없으면 RANDOM)
+     * @param size                  추천 문제 수 (1~5)
+     * @param excludeQuestionUuids  제외할 문제 UUID 목록 (세션 내 이미 노출된 문제 등)
+     * @param memberUuid            회원 UUID (없으면 RANDOM)
      * @return 추천 문제 목록
      */
-    public RecommendationsResponse recommend(int size, UUID excludeQuestionUuid, UUID memberUuid) {
+    public RecommendationsResponse recommend(int size, List<UUID> excludeQuestionUuids, UUID memberUuid) {
         // RAG/RANDOM 경로 모두 동일한 범위 적용
         int clamped = Math.max(1, Math.min(size, 5));
         if (memberUuid != null) {
-            RecommendationsResponse aiResult = tryAiRecommend(memberUuid, clamped, excludeQuestionUuid);
+            RecommendationsResponse aiResult = tryAiRecommend(memberUuid, clamped, excludeQuestionUuids);
             if (aiResult != null && !aiResult.questions().isEmpty()) {
                 return aiResult;
             }
             log.info("[recommendation] AI 추천 결과 없음, RANDOM fallback: memberUuid={}", memberUuid);
         }
-        return questionService.getRecommendations(clamped, excludeQuestionUuid);
+        return questionService.getRecommendations(clamped, excludeQuestionUuids);
     }
 
     /**
@@ -66,7 +66,7 @@ public class RecommendationService {
      *
      * @return 추천 결과 (AI 추천 불가 또는 결과 없으면 null → 호출부에서 RANDOM fallback)
      */
-    private RecommendationsResponse tryAiRecommend(UUID memberUuid, int size, UUID excludeQuestionUuid) {
+    private RecommendationsResponse tryAiRecommend(UUID memberUuid, int size, List<UUID> excludeQuestionUuids) {
         try {
             String memberUuidStr = memberUuid.toString();
 
@@ -83,10 +83,10 @@ public class RecommendationService {
             // 이미 푼 문제 UUID 목록 — Qdrant must_not 필터 (최근 N건만 전송)
             List<String> solved = submissionRepository.findSolvedQuestionUuids(memberUuidStr, SOLVED_QUESTION_LIMIT);
 
-            // excludeQuestionUuid도 제외 목록에 추가 (오늘의 문제 등)
+            // 세션 내 이미 노출된 문제도 전부 제외 (새로고침 시 중복 방지)
             List<String> mustNotIds = new ArrayList<>(solved);
-            if (excludeQuestionUuid != null) {
-                mustNotIds.add(excludeQuestionUuid.toString());
+            if (excludeQuestionUuids != null) {
+                excludeQuestionUuids.forEach(uuid -> mustNotIds.add(uuid.toString()));
             }
 
             RecommendResult result = aiGatewayClient.recommend(

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionRepository.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionRepository.java
@@ -53,6 +53,10 @@ public interface QuestionRepository extends JpaRepository<Question, UUID> {
     @Query(value = "SELECT * FROM question WHERE is_active = true AND question_uuid <> CAST(:excludeUuid AS uuid) ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
     List<Question> findRandomActiveExcluding(@Param("size") int size, @Param("excludeUuid") String excludeUuid);
 
+    // 복수 UUID 제외 — 세션 내 이미 추천된 문제를 제외할 때 사용
+    @Query(value = "SELECT * FROM question WHERE is_active = true AND question_uuid::text NOT IN (:excludeUuids) ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
+    List<Question> findRandomActiveExcludingList(@Param("size") int size, @Param("excludeUuids") List<String> excludeUuids);
+
     @Query("SELECT q.questionUuid FROM Question q WHERE q.isActive = true ORDER BY q.createdAt ASC")
     List<UUID> findActiveUuidsOrderedByCreatedAt();
 

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionRepository.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionRepository.java
@@ -49,12 +49,9 @@ public interface QuestionRepository extends JpaRepository<Question, UUID> {
     @Query(value = "SELECT * FROM question WHERE is_active = true ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
     List<Question> findRandomActive(@Param("size") int size);
 
-    // PostgreSQL: CAST(:param AS uuid) 사용 (::uuid는 Hibernate 파라미터 파싱 오류 유발)
-    @Query(value = "SELECT * FROM question WHERE is_active = true AND question_uuid <> CAST(:excludeUuid AS uuid) ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
-    List<Question> findRandomActiveExcluding(@Param("size") int size, @Param("excludeUuid") String excludeUuid);
-
     // 복수 UUID 제외 — 세션 내 이미 추천된 문제를 제외할 때 사용
-    @Query(value = "SELECT * FROM question WHERE is_active = true AND question_uuid::text NOT IN (:excludeUuids) ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
+    // CAST(... AS varchar): 프로젝트 기존 패턴 통일 (::text 캐스팅 대신)
+    @Query(value = "SELECT * FROM question WHERE is_active = true AND CAST(question_uuid AS varchar) NOT IN (:excludeUuids) ORDER BY RANDOM() LIMIT :size", nativeQuery = true)
     List<Question> findRandomActiveExcludingList(@Param("size") int size, @Param("excludeUuids") List<String> excludeUuids);
 
     @Query("SELECT q.questionUuid FROM Question q WHERE q.isActive = true ORDER BY q.createdAt ASC")

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/service/QuestionService.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/service/QuestionService.java
@@ -33,6 +33,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -155,18 +156,23 @@ public class QuestionService {
      * RANDOM 기반 추천.
      * memberUuid 없거나 AI 추천 실패 시 호출되는 fallback.
      */
-    public RecommendationsResponse getRecommendations(int size, UUID excludeQuestionUuid) {
+    public RecommendationsResponse getRecommendations(int size, List<UUID> excludeQuestionUuids) {
         int clamped = Math.max(1, Math.min(size, 5));
-        UUID exclude = excludeQuestionUuid;
-        if (exclude == null) {
-            DailyChallenge dc = dailyChallengeRepository.findByChallengeDate(LocalDate.now()).orElse(null);
-            if (dc != null) {
-                exclude = dc.getQuestionUuid();
-            }
+
+        // 오늘의 문제도 제외 목록에 추가
+        List<String> excludeList = new ArrayList<>(
+                excludeQuestionUuids != null
+                        ? excludeQuestionUuids.stream().map(UUID::toString).toList()
+                        : List.of()
+        );
+        DailyChallenge dc = dailyChallengeRepository.findByChallengeDate(LocalDate.now()).orElse(null);
+        if (dc != null) {
+            excludeList.add(dc.getQuestionUuid().toString());
         }
-        List<Question> list = (exclude != null)
-                ? questionRepository.findRandomActiveExcluding(clamped, exclude.toString())
-                : questionRepository.findRandomActive(clamped);
+
+        List<Question> list = excludeList.isEmpty()
+                ? questionRepository.findRandomActive(clamped)
+                : questionRepository.findRandomActiveExcludingList(clamped, excludeList);
         return new RecommendationsResponse(list.stream().map(this::toSummary).toList());
     }
 

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionController.java
@@ -76,9 +76,14 @@ public class QuestionController implements QuestionControllerDocs {
     public ResponseEntity<RecommendationsResponse> getRecommendations(
         @AuthMember LoginMember loginMember,
         @RequestParam(defaultValue = "3") int size,
-        @RequestParam(required = false) UUID excludeQuestionUuid
+        @RequestParam(required = false) List<String> excludeQuestionUuids
     ) {
-        return ResponseEntity.ok(recommendationService.recommend(size, excludeQuestionUuid, loginMember.memberUuid()));
+        // String → UUID 변환 — Controller는 변환만 담당
+        List<UUID> excludeUuids = excludeQuestionUuids == null ? List.of() :
+                excludeQuestionUuids.stream()
+                        .map(UUID::fromString)
+                        .toList();
+        return ResponseEntity.ok(recommendationService.recommend(size, excludeUuids, loginMember.memberUuid()));
     }
 
     @GetMapping("/{questionUuid}")

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionControllerDocs.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -57,15 +58,16 @@ public interface QuestionControllerDocs {
       @ApiLog(date = "2026.04.08", author = Author.SUHSAECHAN, issueNumber = 6, description = "추천 문제 조회 API 추가"),
       @ApiLog(date = "2026.04.08", author = Author.SUHSAECHAN, issueNumber = 22, description = "네이티브 쿼리를 exclude 유무 기준 2분기로 분리하여 UUID 바인딩 타입 안전성 확보"),
       @ApiLog(date = "2026.04.13", author = Author.SUHSAECHAN, issueNumber = 63, description = "memberUuid 파라미터 추가 — RAG 기반 개인화 추천 도입, RecommendationService 위임, 오답 없거나 AI 실패 시 RANDOM fallback"),
+      @ApiLog(date = "2026.04.24", author = Author.SUHSAECHAN, issueNumber = 284, description = "excludeQuestionUuids 복수 파라미터로 변경 — 세션 내 중복 노출 제외 지원"),
   })
   @Operation(summary = "추천 문제 조회",
       description = "JWT 인증 회원 기준 RAG 기반 개인화 추천(최근 오답 벡터 평균 → Qdrant 유사도 검색). " +
           "오답 기록 없으면 활성 문제 풀에서 RANDOM 추천. " +
-          "size 기본 3, 최대 5. excludeQuestionUuid 미지정 시 오늘의 데일리 챌린지 자동 제외.")
+          "size 기본 3, 최대 5. excludeQuestionUuids 미지정 시 오늘의 데일리 챌린지 자동 제외.")
   ResponseEntity<RecommendationsResponse> getRecommendations(
       @AuthMember LoginMember loginMember,
       @RequestParam(defaultValue = "3") int size,
-      @RequestParam(required = false) UUID excludeQuestionUuid
+      @RequestParam(required = false) List<String> excludeQuestionUuids
   );
 
   @ApiLogs({


### PR DESCRIPTION
## Summary

- 홈 화면 AI 추천 문제 새로고침 버튼 클릭 시 이번 세션에서 이미 추천된 문제를 제외하고 새 문제를 반환
- 백엔드: `excludeQuestionUuid`(단수) → `excludeQuestionUuids`(복수 List)로 확장 (Controller → RecommendationService → QuestionService → Repository)
- 프론트: `seenUuids` state를 세션 동안 누적하여 다음 추천 요청 시 제외 목록으로 전달, 브라우저 새로고침 시 자연 초기화

## Test Plan

- [ ] 홈 화면 진입 후 추천 문제 3개 UUID 메모
- [ ] 새로고침 버튼 3회 클릭 — 총 9개 UUID가 모두 다른지 확인
- [ ] Network 탭에서 `excludeQuestionUuids` 파라미터가 반복 append 형태로 전달되는지 확인
- [ ] 브라우저 F5 새로고침 후 최초 요청에 `excludeQuestionUuids` 파라미터가 없는지 확인

Closes #284