### PR TITLE
🚀[기능개선][문제풀이] 문제풀이 선택지 생성 모드 연습/실전 분리

### DIFF
--- a/client/src/api/members.ts
+++ b/client/src/api/members.ts
@@ -4,6 +4,7 @@ import type {
   NicknameRegenerateResponse,
   NicknameCheckResponse,
   NicknameChangeResponse,
+  ChoiceGenerationMode,
 } from "../types/api";
 
 export function fetchMe(): Promise<MemberMeResponse> {
@@ -25,5 +26,15 @@ export function changeNickname(nickname: string): Promise<NicknameChangeResponse
   return apiFetch("/members/me/nickname", {
     method: "PATCH",
     body: JSON.stringify({ nickname }),
+  });
+}
+
+// 선택지 생성 모드 변경
+export function updateChoiceGenerationMode(
+  mode: ChoiceGenerationMode
+): Promise<{ choiceGenerationMode: ChoiceGenerationMode }> {
+  return apiFetch("/members/me/settings/choice-generation-mode", {
+    method: "PATCH",
+    body: JSON.stringify({ choiceGenerationMode: mode }),
   });
 }

--- a/client/src/hooks/useMember.ts
+++ b/client/src/hooks/useMember.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { fetchMe, regenerateNickname, checkNickname, changeNickname } from "../api/members";
+import { fetchMe, regenerateNickname, checkNickname, changeNickname, updateChoiceGenerationMode } from "../api/members";
 import { useAuthStore } from "../stores/authStore";
-import type { NicknameCheckResponse, NicknameChangeResponse } from "../types/api";
+import type { NicknameCheckResponse, NicknameChangeResponse, ChoiceGenerationMode } from "../types/api";
 
 export function useMember() {
   const accessToken = useAuthStore((s) => s.accessToken);
@@ -51,6 +51,22 @@ export function useChangeNickname() {
     mutationFn: (nickname: string) => changeNickname(nickname),
     onSuccess: (result) => {
       setNickname(result.nickname);
+      queryClient.invalidateQueries({ queryKey: ["member"] });
+    },
+  });
+}
+
+// 선택지 생성 모드 변경 뮤테이션 — 성공 시 member 쿼리 무효화
+export function useUpdateChoiceGenerationMode() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { choiceGenerationMode: ChoiceGenerationMode },
+    Error,
+    ChoiceGenerationMode
+  >({
+    mutationFn: (mode: ChoiceGenerationMode) => updateChoiceGenerationMode(mode),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["member"] });
     },
   });

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -36,9 +36,9 @@ export default function Settings() {
   const stagger = useStagger();
   const s0 = stagger(0); // h1 "설정"
   const s1 = stagger(1); // 계정 섹션
-  const s2 = stagger(2); // 건의사항 row
-  const s3 = stagger(3); // 앱 정보 섹션
-  const s4 = stagger(4); // 문제풀이 섹션
+  const s2 = stagger(2); // 문제풀이 섹션
+  const s3 = stagger(3); // 이용안내 섹션
+  const s4 = stagger(4); // 앱 정보 섹션
   const s5 = stagger(5); // 로그아웃 섹션
   const s6 = stagger(6); // 로고 + 카피라이트
 
@@ -146,36 +146,8 @@ export default function Settings() {
         </SettingsSection>
       </section>
 
-      {/* ③ 이용안내 섹션 — 서브페이지 진입 row */}
+      {/* ③ 문제풀이 섹션 */}
       <section className={s2.className}>
-        <SettingsSection label="이용안내">
-          <div className="bg-surface-card border-y border-border divide-y divide-border">
-            <SettingsRow
-              label="건의사항"
-              value={<p className="text-sm text-text-secondary">의견 남기기</p>}
-              action={<ChevronRight size={16} className="text-text-caption" />}
-              onClick={() => navigate("/settings/feedback")}
-            />
-          </div>
-        </SettingsSection>
-      </section>
-
-      {/* ④ 앱 정보 섹션 */}
-      <section className={s3.className}>
-        <SettingsSection label="앱 정보">
-          <div className="bg-surface-card border-y border-border divide-y divide-border">
-            <SettingsRow
-              label="버전"
-              value={
-                <p className="text-sm text-text-caption">{__APP_VERSION__}</p>
-              }
-            />
-          </div>
-        </SettingsSection>
-      </section>
-
-      {/* ③-1 문제풀이 섹션 */}
-      <section className={s4.className}>
         <SettingsSection label="문제풀이">
           <div className="bg-surface-card border-y border-border">
             <div className="px-4 py-3.5">
@@ -186,7 +158,7 @@ export default function Settings() {
                     type="button"
                     disabled={isModeUpdating}
                     onClick={() => updateMode("PRACTICE")}
-                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors ${
+                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                       currentMode === "PRACTICE"
                         ? "bg-brand text-white"
                         : "text-text-caption hover:text-text-secondary"
@@ -198,7 +170,7 @@ export default function Settings() {
                     type="button"
                     disabled={isModeUpdating}
                     onClick={() => updateMode("REAL")}
-                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors ${
+                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                       currentMode === "REAL"
                         ? "bg-brand text-white"
                         : "text-text-caption hover:text-text-secondary"
@@ -218,7 +190,35 @@ export default function Settings() {
         </SettingsSection>
       </section>
 
-      {/* ⑤ 로그아웃 */}
+      {/* ④ 이용안내 섹션 — 서브페이지 진입 row */}
+      <section className={s3.className}>
+        <SettingsSection label="이용안내">
+          <div className="bg-surface-card border-y border-border divide-y divide-border">
+            <SettingsRow
+              label="건의사항"
+              value={<p className="text-sm text-text-secondary">의견 남기기</p>}
+              action={<ChevronRight size={16} className="text-text-caption" />}
+              onClick={() => navigate("/settings/feedback")}
+            />
+          </div>
+        </SettingsSection>
+      </section>
+
+      {/* ⑤ 앱 정보 섹션 */}
+      <section className={s4.className}>
+        <SettingsSection label="앱 정보">
+          <div className="bg-surface-card border-y border-border divide-y divide-border">
+            <SettingsRow
+              label="버전"
+              value={
+                <p className="text-sm text-text-caption">{__APP_VERSION__}</p>
+              }
+            />
+          </div>
+        </SettingsSection>
+      </section>
+
+      {/* ⑥ 로그아웃 */}
       <section className={s5.className}>
         <SettingsSection label="계정 관리">
           <div className="bg-surface-card border-y border-border">
@@ -241,7 +241,7 @@ export default function Settings() {
         </SettingsSection>
       </section>
 
-      {/* ⑥ 로고 + 카피라이트 */}
+      {/* ⑦ 로고 + 카피라이트 */}
       <section className={`text-center mt-12 space-y-2 ${s6.className}`}>
         <img src={logo} alt="passQL" className="h-5 w-auto mx-auto" />
         <p className="text-xs text-text-caption">

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -156,7 +156,7 @@ export default function Settings() {
                 <div className="flex gap-1 bg-surface rounded-lg p-0.5">
                   <button
                     type="button"
-                    disabled={isModeUpdating}
+                    disabled={isModeUpdating || currentMode === "PRACTICE"}
                     onClick={() => updateMode("PRACTICE")}
                     className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                       currentMode === "PRACTICE"
@@ -168,7 +168,7 @@ export default function Settings() {
                   </button>
                   <button
                     type="button"
-                    disabled={isModeUpdating}
+                    disabled={isModeUpdating || currentMode === "REAL"}
                     onClick={() => updateMode("REAL")}
                     className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                       currentMode === "REAL"

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -8,7 +8,8 @@ import NicknameChangeModal from "../components/NicknameChangeModal";
 import { useStagger } from "../hooks/useStagger";
 import SettingsSection from "../components/SettingsSection";
 import SettingsRow from "../components/SettingsRow";
-import { useMember } from "../hooks/useMember";
+import { useMember, useUpdateChoiceGenerationMode } from "../hooks/useMember";
+import type { ChoiceGenerationMode } from "../types/api";
 import { isNicknameCooldown, formatNicknameCooldownMessage } from "../lib/dateUtil";
 
 export default function Settings() {
@@ -23,6 +24,8 @@ export default function Settings() {
   const [isNicknameModalOpen, setIsNicknameModalOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [logoutLoading, setLogoutLoading] = useState(false);
+  const { mutate: updateMode, isPending: isModeUpdating } = useUpdateChoiceGenerationMode();
+  const currentMode: ChoiceGenerationMode = memberData?.choiceGenerationMode ?? "PRACTICE";
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // toast 메시지 — null이면 미표시
@@ -35,8 +38,9 @@ export default function Settings() {
   const s1 = stagger(1); // 계정 섹션
   const s2 = stagger(2); // 건의사항 row
   const s3 = stagger(3); // 앱 정보 섹션
-  const s4 = stagger(4); // 로그아웃 섹션
-  const s5 = stagger(5); // 로고 + 카피라이트
+  const s4 = stagger(4); // 문제풀이 섹션
+  const s5 = stagger(5); // 로그아웃 섹션
+  const s6 = stagger(6); // 로고 + 카피라이트
 
   useEffect(() => {
     return () => {
@@ -170,8 +174,52 @@ export default function Settings() {
         </SettingsSection>
       </section>
 
-      {/* ⑤ 로그아웃 */}
+      {/* ③-1 문제풀이 섹션 */}
       <section className={s4.className}>
+        <SettingsSection label="문제풀이">
+          <div className="bg-surface-card border-y border-border">
+            <div className="px-4 py-3.5">
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-sm font-medium text-text-primary">선택지 생성 모드</span>
+                <div className="flex gap-1 bg-surface rounded-lg p-0.5">
+                  <button
+                    type="button"
+                    disabled={isModeUpdating}
+                    onClick={() => updateMode("PRACTICE")}
+                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors ${
+                      currentMode === "PRACTICE"
+                        ? "bg-brand text-white"
+                        : "text-text-caption hover:text-text-secondary"
+                    }`}
+                  >
+                    연습
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isModeUpdating}
+                    onClick={() => updateMode("REAL")}
+                    className={`text-xs px-3 py-1 rounded-md font-semibold transition-colors ${
+                      currentMode === "REAL"
+                        ? "bg-brand text-white"
+                        : "text-text-caption hover:text-text-secondary"
+                    }`}
+                  >
+                    실전
+                  </button>
+                </div>
+              </div>
+              <p className="text-xs text-text-caption">
+                {currentMode === "PRACTICE"
+                  ? "기존 검증된 선택지 재사용 → 빠르게 시작"
+                  : "매번 새 선택지 AI 생성 → 대기 있음"}
+              </p>
+            </div>
+          </div>
+        </SettingsSection>
+      </section>
+
+      {/* ⑤ 로그아웃 */}
+      <section className={s5.className}>
         <SettingsSection label="계정 관리">
           <div className="bg-surface-card border-y border-border">
             <button
@@ -194,7 +242,7 @@ export default function Settings() {
       </section>
 
       {/* ⑥ 로고 + 카피라이트 */}
-      <section className={`text-center mt-12 space-y-2 ${s5.className}`}>
+      <section className={`text-center mt-12 space-y-2 ${s6.className}`}>
         <img src={logo} alt="passQL" className="h-5 w-auto mx-auto" />
         <p className="text-xs text-text-caption">
           © 2026 passQL. All rights reserved.

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -233,6 +233,9 @@ export interface MemberRegisterResponse {
   readonly nickname: string;
 }
 
+// 선택지 생성 모드
+export type ChoiceGenerationMode = "PRACTICE" | "REAL";
+
 export interface MemberMeResponse {
   readonly memberUuid: string;
   readonly nickname: string;
@@ -243,6 +246,7 @@ export interface MemberMeResponse {
   readonly lastSeenAt: string;
   // null이면 닉네임을 한 번도 변경하지 않은 상태
   readonly nicknameChangedAt: string | null;
+  readonly choiceGenerationMode: ChoiceGenerationMode;
 }
 
 export interface NicknameRegenerateResponse {

--- a/server/PQL-Application/src/main/java/com/passql/application/service/QuizSessionService.java
+++ b/server/PQL-Application/src/main/java/com/passql/application/service/QuizSessionService.java
@@ -13,6 +13,8 @@ import com.passql.question.entity.QuizSession;
 import com.passql.question.repository.QuestionChoiceSetItemRepository;
 import com.passql.question.repository.QuestionRepository;
 import com.passql.question.repository.QuizSessionRepository;
+import com.passql.member.constant.ChoiceGenerationMode;
+import com.passql.member.service.MemberService;
 import com.passql.question.service.ChoiceSetResolver;
 import com.passql.question.service.QuestionService;
 import com.passql.submission.entity.Submission;
@@ -43,6 +45,7 @@ public class QuizSessionService {
     private final ChoiceSetResolver choiceSetResolver;
     private final PrefetchService prefetchService;
     private final ObjectMapper objectMapper;
+    private final MemberService memberService;
 
     /**
      * 퀴즈 세션을 생성한다. 활성 AI_ONLY 문제 중 최대 10개를 무작위 픽.
@@ -92,7 +95,8 @@ public class QuizSessionService {
         UUID questionUuid = order.get(index);
 
         Question question = questionService.getQuestionEntity(questionUuid);
-        QuestionChoiceSet choiceSet = choiceSetResolver.resolveForUser(questionUuid, session.getMemberUuid());
+        ChoiceGenerationMode mode = memberService.getChoiceGenerationMode(session.getMemberUuid());
+        QuestionChoiceSet choiceSet = choiceSetResolver.resolveForUser(questionUuid, session.getMemberUuid(), mode);
         List<QuestionChoiceSetItem> items = choiceSetItemRepository
                 .findByChoiceSetUuidOrderBySortOrderAsc(choiceSet.getChoiceSetUuid());
 

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/constant/ChoiceGenerationMode.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/constant/ChoiceGenerationMode.java
@@ -1,0 +1,8 @@
+package com.passql.member.constant;
+
+public enum ChoiceGenerationMode {
+    /** 기존 검증된 선택지 재사용 우선 — 없을 때만 AI 실시간 생성 */
+    PRACTICE,
+    /** 기존 선택지 유무와 무관하게 항상 AI 실시간 생성 */
+    REAL
+}

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/ChoiceGenerationModeUpdateRequest.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/ChoiceGenerationModeUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.passql.member.dto;
+
+import com.passql.member.constant.ChoiceGenerationMode;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChoiceGenerationModeUpdateRequest {
+
+    @NotNull
+    private ChoiceGenerationMode choiceGenerationMode;
+}

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/ChoiceGenerationModeUpdateResponse.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/ChoiceGenerationModeUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.passql.member.dto;
+
+import com.passql.member.constant.ChoiceGenerationMode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChoiceGenerationModeUpdateResponse {
+
+    private ChoiceGenerationMode choiceGenerationMode;
+}

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/MemberMeResponse.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/dto/MemberMeResponse.java
@@ -1,5 +1,6 @@
 package com.passql.member.dto;
 
+import com.passql.member.constant.ChoiceGenerationMode;
 import com.passql.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +21,8 @@ public class MemberMeResponse {
     private LocalDateTime lastSeenAt;
     // 닉네임 쿨다운 계산 기준 — null이면 변경 이력 없음
     private LocalDateTime nicknameChangedAt;
+    // 선택지 생성 모드 — PRACTICE(기본): 재사용, REAL: 항상 새로 생성
+    private ChoiceGenerationMode choiceGenerationMode;
 
     public static MemberMeResponse from(Member m) {
         return new MemberMeResponse(
@@ -30,7 +33,8 @@ public class MemberMeResponse {
             m.getIsTestAccount(),
             m.getCreatedAt(),
             m.getLastSeenAt(),
-            m.getNicknameChangedAt()
+            m.getNicknameChangedAt(),
+            m.getChoiceGenerationMode()
         );
     }
 }

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/entity/Member.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.passql.member.entity;
 
 import com.passql.common.entity.SoftDeletableBaseEntity;
 import com.passql.member.constant.AuthProvider;
+import com.passql.member.constant.ChoiceGenerationMode;
 import com.passql.member.constant.MemberRole;
 import com.passql.member.constant.MemberStatus;
 import jakarta.persistence.*;
@@ -92,6 +93,11 @@ public class Member extends SoftDeletableBaseEntity {
 
     @Column(length = 45)
     private String lastLoginIp;
+
+    // 선택지 생성 모드 — PRACTICE: 기존 재사용, REAL: 항상 새로 생성
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private ChoiceGenerationMode choiceGenerationMode = ChoiceGenerationMode.PRACTICE;
 
     // === 정적 팩토리 ===
 

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/service/MemberService.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/service/MemberService.java
@@ -5,6 +5,8 @@ import com.passql.common.exception.constant.ErrorCode;
 import com.passql.common.util.NicknameGenerator;
 import com.passql.member.constant.MemberStatus;
 import com.passql.member.dto.MemberMeResponse;
+import com.passql.member.dto.ChoiceGenerationModeUpdateRequest;
+import com.passql.member.dto.ChoiceGenerationModeUpdateResponse;
 import com.passql.member.dto.NicknameChangeRequest;
 import com.passql.member.dto.NicknameChangeResponse;
 import com.passql.member.dto.NicknameCheckResponse;
@@ -99,6 +101,15 @@ public class MemberService {
     public NicknameCheckResponse checkNickname(String nickname) {
         boolean available = !memberRepository.existsByNicknameAndIsDeletedFalse(nickname);
         return new NicknameCheckResponse(available);
+    }
+
+    /** 선택지 생성 모드 변경 — 트랜잭션 내 즉시 반영. */
+    @Transactional
+    public ChoiceGenerationModeUpdateResponse updateChoiceGenerationMode(
+            UUID memberUuid, ChoiceGenerationModeUpdateRequest request) {
+        Member member = findActiveMember(memberUuid);
+        member.setChoiceGenerationMode(request.getChoiceGenerationMode());
+        return new ChoiceGenerationModeUpdateResponse(member.getChoiceGenerationMode());
     }
 
     // 닉네임 직접 변경 — 쿨다운, 중복 검증 포함

--- a/server/PQL-Domain-Member/src/main/java/com/passql/member/service/MemberService.java
+++ b/server/PQL-Domain-Member/src/main/java/com/passql/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.passql.common.exception.constant.ErrorCode;
 import com.passql.common.util.NicknameGenerator;
 import com.passql.member.constant.MemberStatus;
 import com.passql.member.dto.MemberMeResponse;
+import com.passql.member.constant.ChoiceGenerationMode;
 import com.passql.member.dto.ChoiceGenerationModeUpdateRequest;
 import com.passql.member.dto.ChoiceGenerationModeUpdateResponse;
 import com.passql.member.dto.NicknameChangeRequest;
@@ -101,6 +102,16 @@ public class MemberService {
     public NicknameCheckResponse checkNickname(String nickname) {
         boolean available = !memberRepository.existsByNicknameAndIsDeletedFalse(nickname);
         return new NicknameCheckResponse(available);
+    }
+
+    /** 선택지 생성 모드 조회 — 미존재·탈퇴 회원은 PRACTICE 폴백. */
+    public ChoiceGenerationMode getChoiceGenerationMode(UUID memberUuid) {
+        return memberRepository.findByMemberUuidAndIsDeletedFalse(memberUuid)
+                .map(Member::getChoiceGenerationMode)
+                .orElseGet(() -> {
+                    log.warn("[member] choiceGenerationMode 조회 실패, PRACTICE 폴백: memberUuid={}", memberUuid);
+                    return ChoiceGenerationMode.PRACTICE;
+                });
     }
 
     /** 선택지 생성 모드 변경 — 트랜잭션 내 즉시 반영. */

--- a/server/PQL-Domain-Question/build.gradle
+++ b/server/PQL-Domain-Question/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     api project(':PQL-Common')
     api project(':PQL-Domain-Meta')
     api project(':PQL-Domain-AI')
+    implementation project(':PQL-Domain-Member')
 
     // 테스트
     testImplementation project(':PQL-Web')

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionChoiceSetRepository.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionChoiceSetRepository.java
@@ -30,6 +30,14 @@ public interface QuestionChoiceSetRepository extends JpaRepository<QuestionChoic
 
     List<QuestionChoiceSet> findByQuestionUuidOrderByCreatedAtDesc(UUID questionUuid);
 
+    /**
+     * 연습 모드 재사용 조회: 특정 문제에 대해 status=OK인 선택지 중 가장 최근 것.
+     * generatedForMemberUuid 무관 — 다른 사용자가 생성한 것도 재사용 가능.
+     */
+    Optional<QuestionChoiceSet>
+        findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(
+            UUID questionUuid, ChoiceSetStatus status);
+
     @Modifying
     @Transactional
     void deleteByQuestionUuid(UUID questionUuid);

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionChoiceSetRepository.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/repository/QuestionChoiceSetRepository.java
@@ -5,8 +5,10 @@ import com.passql.question.constant.ChoiceSetStatus;
 import com.passql.question.entity.QuestionChoiceSet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +39,12 @@ public interface QuestionChoiceSetRepository extends JpaRepository<QuestionChoic
     Optional<QuestionChoiceSet>
         findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(
             UUID questionUuid, ChoiceSetStatus status);
+
+    /** 프리페치 소비 마킹 — 별도 @Transactional 빈 없이 Repository 레벨에서 직접 처리. */
+    @Modifying
+    @Transactional
+    @Query("UPDATE QuestionChoiceSet q SET q.consumedAt = :consumedAt WHERE q.choiceSetUuid = :choiceSetUuid")
+    void markConsumed(UUID choiceSetUuid, LocalDateTime consumedAt);
 
     @Modifying
     @Transactional

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
@@ -2,6 +2,9 @@ package com.passql.question.service;
 
 import com.passql.common.exception.CustomException;
 import com.passql.common.exception.constant.ErrorCode;
+import com.passql.member.constant.ChoiceGenerationMode;
+import com.passql.member.entity.Member;
+import com.passql.member.repository.MemberRepository;
 import com.passql.question.constant.ChoiceSetSource;
 import com.passql.question.constant.ChoiceSetStatus;
 import com.passql.question.constant.ExecutionMode;
@@ -28,30 +31,23 @@ public class ChoiceSetResolver {
     private final QuestionService questionService;
     private final QuestionChoiceSetRepository choiceSetRepository;
     private final ChoiceSetGenerationService choiceSetGenerationService;
+    private final MemberRepository memberRepository;
 
-    /**
-     * questionUuid + memberUuid 로 사용자에게 제공할 선택지 세트를 결정한다.
-     * <p>
-     * 비트랜잭션 — AI·샌드박스 호출이 수 초 걸리므로 긴 트랜잭션 금지.
-     * consumed_at 마킹은 markConsumed()에서 짧은 트랜잭션으로 처리.
-     *
-     * @return 사용 가능한 QuestionChoiceSet
-     */
     public QuestionChoiceSet resolveForUser(UUID questionUuid, UUID memberUuid) {
         Question question = questionService.getQuestionEntity(questionUuid);
+        ChoiceGenerationMode mode = getMemberMode(memberUuid);
 
-        // CONCEPT_ONLY 문제는 Sandbox 없이 텍스트 선택지를 AI로 생성
         if (question.getExecutionMode() == ExecutionMode.CONCEPT_ONLY) {
-            return resolveConcept(questionUuid, memberUuid);
+            return resolveConcept(questionUuid, memberUuid, mode);
         }
 
         switch (question.getChoiceSetPolicy()) {
             case AI_ONLY:
-                return resolveAiOnly(questionUuid, memberUuid);
+                return resolveAiOnly(questionUuid, memberUuid, mode);
             case ODD_ONE_OUT:
-                return resolveAiOnly(questionUuid, memberUuid);
+                return resolveAiOnly(questionUuid, memberUuid, mode);
             case RESULT_MATCH:
-                return resolveResultMatch(questionUuid, memberUuid);
+                return resolveResultMatch(questionUuid, memberUuid, mode);
             case CURATED_ONLY:
                 throw new CustomException(ErrorCode.CHOICE_SET_POLICY_NOT_IMPLEMENTED,
                         "CURATED_ONLY 정책은 아직 지원되지 않습니다.");
@@ -64,66 +60,88 @@ public class ChoiceSetResolver {
         }
     }
 
-    /**
-     * CONCEPT_ONLY 문제: 프리페치 캐시 조회 후 없으면 텍스트 선택지 실시간 생성.
-     * Sandbox 검증 없이 AI가 직접 정답/오답을 판별한다.
-     */
-    private QuestionChoiceSet resolveConcept(UUID questionUuid, UUID memberUuid) {
+    /** 멤버의 선택지 생성 모드 조회. 멤버 미존재 시 PRACTICE 폴백. */
+    private ChoiceGenerationMode getMemberMode(UUID memberUuid) {
+        return memberRepository.findById(memberUuid)
+                .map(Member::getChoiceGenerationMode)
+                .orElse(ChoiceGenerationMode.PRACTICE);
+    }
+
+    private QuestionChoiceSet resolveConcept(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
+        if (mode == ChoiceGenerationMode.REAL) {
+            log.info("[resolver] concept REAL mode, runtime generation: questionUuid={}", questionUuid);
+            return choiceSetGenerationService.generateConcept(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
+        }
+
+        // 연습 모드: 1순위 본인 프리페치 → 2순위 전체 OK → 미스 시 생성
         Optional<QuestionChoiceSet> prefetched = choiceSetRepository
                 .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
-                        questionUuid, memberUuid,
-                        ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
-
+                        questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
         if (prefetched.isPresent()) {
-            QuestionChoiceSet set = prefetched.get();
-            markConsumed(set);
-            log.info("[resolver] concept prefetch HIT: questionUuid={}, setUuid={}",
-                    questionUuid, set.getChoiceSetUuid());
-            return set;
+            markConsumed(prefetched.get());
+            log.info("[resolver] concept prefetch HIT: questionUuid={}", questionUuid);
+            return prefetched.get();
+        }
+
+        Optional<QuestionChoiceSet> reusable = choiceSetRepository
+                .findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(questionUuid, ChoiceSetStatus.OK);
+        if (reusable.isPresent()) {
+            log.info("[resolver] concept PRACTICE reuse HIT: questionUuid={}", questionUuid);
+            return reusable.get();
         }
 
         log.info("[resolver] concept MISS, runtime generation: questionUuid={}", questionUuid);
         return choiceSetGenerationService.generateConcept(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
     }
 
-    private QuestionChoiceSet resolveAiOnly(UUID questionUuid, UUID memberUuid) {
-        // 1. 프리페치 캐시 조회
-        Optional<QuestionChoiceSet> prefetched = choiceSetRepository
-                .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
-                        questionUuid, memberUuid,
-                        ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
-
-        if (prefetched.isPresent()) {
-            // 2. HIT: consumed_at 마킹 후 반환
-            QuestionChoiceSet set = prefetched.get();
-            markConsumed(set);
-            log.info("[resolver] prefetch HIT: questionUuid={}, setUuid={}",
-                    questionUuid, set.getChoiceSetUuid());
-            return set;
+    private QuestionChoiceSet resolveAiOnly(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
+        if (mode == ChoiceGenerationMode.REAL) {
+            log.info("[resolver] REAL mode, runtime generation: questionUuid={}", questionUuid);
+            return choiceSetGenerationService.generate(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
         }
 
-        // 3. MISS: 실시간 생성
-        log.info("[resolver] prefetch MISS, runtime generation: questionUuid={}, memberUuid={}",
-                questionUuid, memberUuid);
+        // 연습 모드: 1순위 본인 프리페치 → 2순위 전체 OK → 미스 시 생성
+        Optional<QuestionChoiceSet> prefetched = choiceSetRepository
+                .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
+                        questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
+        if (prefetched.isPresent()) {
+            markConsumed(prefetched.get());
+            log.info("[resolver] prefetch HIT: questionUuid={}", questionUuid);
+            return prefetched.get();
+        }
+
+        Optional<QuestionChoiceSet> reusable = choiceSetRepository
+                .findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(questionUuid, ChoiceSetStatus.OK);
+        if (reusable.isPresent()) {
+            log.info("[resolver] PRACTICE reuse HIT: questionUuid={}", questionUuid);
+            return reusable.get();
+        }
+
+        log.info("[resolver] MISS, runtime generation: questionUuid={}, memberUuid={}", questionUuid, memberUuid);
         return choiceSetGenerationService.generate(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
     }
 
-    /**
-     * RESULT_MATCH 문제: 프리페치 캐시 조회 후 없으면 실시간 생성.
-     * AI가 answerSql 실행 결과를 기반으로 JSON 배열 선택지를 생성한다.
-     */
-    private QuestionChoiceSet resolveResultMatch(UUID questionUuid, UUID memberUuid) {
+    private QuestionChoiceSet resolveResultMatch(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
+        if (mode == ChoiceGenerationMode.REAL) {
+            log.info("[resolver] result-match REAL mode, runtime generation: questionUuid={}", questionUuid);
+            return choiceSetGenerationService.generateResultMatch(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
+        }
+
+        // 연습 모드: 1순위 본인 프리페치 → 2순위 전체 OK → 미스 시 생성
         Optional<QuestionChoiceSet> prefetched = choiceSetRepository
                 .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
-                        questionUuid, memberUuid,
-                        ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
-
+                        questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
         if (prefetched.isPresent()) {
-            QuestionChoiceSet set = prefetched.get();
-            markConsumed(set);
-            log.info("[resolver] result-match prefetch HIT: questionUuid={}, setUuid={}",
-                    questionUuid, set.getChoiceSetUuid());
-            return set;
+            markConsumed(prefetched.get());
+            log.info("[resolver] result-match prefetch HIT: questionUuid={}", questionUuid);
+            return prefetched.get();
+        }
+
+        Optional<QuestionChoiceSet> reusable = choiceSetRepository
+                .findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(questionUuid, ChoiceSetStatus.OK);
+        if (reusable.isPresent()) {
+            log.info("[resolver] result-match PRACTICE reuse HIT: questionUuid={}", questionUuid);
+            return reusable.get();
         }
 
         log.info("[resolver] result-match MISS, runtime generation: questionUuid={}", questionUuid);

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
@@ -60,9 +60,9 @@ public class ChoiceSetResolver {
         }
     }
 
-    /** 멤버의 선택지 생성 모드 조회. 멤버 미존재 시 PRACTICE 폴백. */
+    /** 멤버의 선택지 생성 모드 조회. 미존재·탈퇴 회원은 PRACTICE 폴백. */
     private ChoiceGenerationMode getMemberMode(UUID memberUuid) {
-        return memberRepository.findById(memberUuid)
+        return memberRepository.findByMemberUuidAndIsDeletedFalse(memberUuid)
                 .map(Member::getChoiceGenerationMode)
                 .orElse(ChoiceGenerationMode.PRACTICE);
     }

--- a/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
+++ b/server/PQL-Domain-Question/src/main/java/com/passql/question/service/ChoiceSetResolver.java
@@ -3,8 +3,6 @@ package com.passql.question.service;
 import com.passql.common.exception.CustomException;
 import com.passql.common.exception.constant.ErrorCode;
 import com.passql.member.constant.ChoiceGenerationMode;
-import com.passql.member.entity.Member;
-import com.passql.member.repository.MemberRepository;
 import com.passql.question.constant.ChoiceSetSource;
 import com.passql.question.constant.ChoiceSetStatus;
 import com.passql.question.constant.ExecutionMode;
@@ -14,7 +12,6 @@ import com.passql.question.repository.QuestionChoiceSetRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -22,6 +19,9 @@ import java.util.UUID;
 
 /**
  * 정책에 따라 사용자에게 제공할 선택지 세트를 resolve 한다.
+ * <p>
+ * 호출자(QuestionController)가 memberUuid로 ChoiceGenerationMode를 조회해 전달한다.
+ * 이 컴포넌트는 Member 도메인에 의존하지 않는다.
  */
 @Slf4j
 @Component
@@ -31,11 +31,12 @@ public class ChoiceSetResolver {
     private final QuestionService questionService;
     private final QuestionChoiceSetRepository choiceSetRepository;
     private final ChoiceSetGenerationService choiceSetGenerationService;
-    private final MemberRepository memberRepository;
 
-    public QuestionChoiceSet resolveForUser(UUID questionUuid, UUID memberUuid) {
+    /**
+     * @param mode 호출자가 조회한 사용자의 선택지 생성 모드
+     */
+    public QuestionChoiceSet resolveForUser(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
         Question question = questionService.getQuestionEntity(questionUuid);
-        ChoiceGenerationMode mode = getMemberMode(memberUuid);
 
         if (question.getExecutionMode() == ExecutionMode.CONCEPT_ONLY) {
             return resolveConcept(questionUuid, memberUuid, mode);
@@ -43,7 +44,6 @@ public class ChoiceSetResolver {
 
         switch (question.getChoiceSetPolicy()) {
             case AI_ONLY:
-                return resolveAiOnly(questionUuid, memberUuid, mode);
             case ODD_ONE_OUT:
                 return resolveAiOnly(questionUuid, memberUuid, mode);
             case RESULT_MATCH:
@@ -60,13 +60,6 @@ public class ChoiceSetResolver {
         }
     }
 
-    /** 멤버의 선택지 생성 모드 조회. 미존재·탈퇴 회원은 PRACTICE 폴백. */
-    private ChoiceGenerationMode getMemberMode(UUID memberUuid) {
-        return memberRepository.findByMemberUuidAndIsDeletedFalse(memberUuid)
-                .map(Member::getChoiceGenerationMode)
-                .orElse(ChoiceGenerationMode.PRACTICE);
-    }
-
     private QuestionChoiceSet resolveConcept(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
         if (mode == ChoiceGenerationMode.REAL) {
             log.info("[resolver] concept REAL mode, runtime generation: questionUuid={}", questionUuid);
@@ -78,9 +71,10 @@ public class ChoiceSetResolver {
                 .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
                         questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
         if (prefetched.isPresent()) {
-            markConsumed(prefetched.get());
-            log.info("[resolver] concept prefetch HIT: questionUuid={}", questionUuid);
-            return prefetched.get();
+            QuestionChoiceSet set = prefetched.get();
+            choiceSetRepository.markConsumed(set.getChoiceSetUuid(), LocalDateTime.now());
+            log.info("[resolver] concept prefetch HIT: questionUuid={}, setUuid={}", questionUuid, set.getChoiceSetUuid());
+            return set;
         }
 
         Optional<QuestionChoiceSet> reusable = choiceSetRepository
@@ -96,7 +90,7 @@ public class ChoiceSetResolver {
 
     private QuestionChoiceSet resolveAiOnly(UUID questionUuid, UUID memberUuid, ChoiceGenerationMode mode) {
         if (mode == ChoiceGenerationMode.REAL) {
-            log.info("[resolver] REAL mode, runtime generation: questionUuid={}", questionUuid);
+            log.info("[resolver] ai-only REAL mode, runtime generation: questionUuid={}", questionUuid);
             return choiceSetGenerationService.generate(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
         }
 
@@ -105,19 +99,20 @@ public class ChoiceSetResolver {
                 .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
                         questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
         if (prefetched.isPresent()) {
-            markConsumed(prefetched.get());
-            log.info("[resolver] prefetch HIT: questionUuid={}", questionUuid);
-            return prefetched.get();
+            QuestionChoiceSet set = prefetched.get();
+            choiceSetRepository.markConsumed(set.getChoiceSetUuid(), LocalDateTime.now());
+            log.info("[resolver] ai-only prefetch HIT: questionUuid={}, setUuid={}", questionUuid, set.getChoiceSetUuid());
+            return set;
         }
 
         Optional<QuestionChoiceSet> reusable = choiceSetRepository
                 .findFirstByQuestionUuidAndStatusOrderByCreatedAtDesc(questionUuid, ChoiceSetStatus.OK);
         if (reusable.isPresent()) {
-            log.info("[resolver] PRACTICE reuse HIT: questionUuid={}", questionUuid);
+            log.info("[resolver] ai-only PRACTICE reuse HIT: questionUuid={}", questionUuid);
             return reusable.get();
         }
 
-        log.info("[resolver] MISS, runtime generation: questionUuid={}, memberUuid={}", questionUuid, memberUuid);
+        log.info("[resolver] ai-only MISS, runtime generation: questionUuid={}, memberUuid={}", questionUuid, memberUuid);
         return choiceSetGenerationService.generate(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
     }
 
@@ -132,9 +127,10 @@ public class ChoiceSetResolver {
                 .findFirstByQuestionUuidAndGeneratedForMemberUuidAndSourceAndStatusAndConsumedAtIsNullOrderByCreatedAtDesc(
                         questionUuid, memberUuid, ChoiceSetSource.AI_PREFETCH, ChoiceSetStatus.OK);
         if (prefetched.isPresent()) {
-            markConsumed(prefetched.get());
-            log.info("[resolver] result-match prefetch HIT: questionUuid={}", questionUuid);
-            return prefetched.get();
+            QuestionChoiceSet set = prefetched.get();
+            choiceSetRepository.markConsumed(set.getChoiceSetUuid(), LocalDateTime.now());
+            log.info("[resolver] result-match prefetch HIT: questionUuid={}, setUuid={}", questionUuid, set.getChoiceSetUuid());
+            return set;
         }
 
         Optional<QuestionChoiceSet> reusable = choiceSetRepository
@@ -146,14 +142,5 @@ public class ChoiceSetResolver {
 
         log.info("[resolver] result-match MISS, runtime generation: questionUuid={}", questionUuid);
         return choiceSetGenerationService.generateResultMatch(questionUuid, memberUuid, ChoiceSetSource.AI_RUNTIME);
-    }
-
-    /**
-     * 프리페치 캐시 소비 마킹 — 짧은 트랜잭션으로 처리.
-     */
-    @Transactional
-    protected void markConsumed(QuestionChoiceSet set) {
-        set.setConsumedAt(LocalDateTime.now());
-        choiceSetRepository.save(set);
     }
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/MemberController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.passql.web.controller;
 
 import com.passql.member.auth.presentation.annotation.AuthMember;
 import com.passql.member.auth.presentation.security.LoginMember;
+import com.passql.member.dto.ChoiceGenerationModeUpdateRequest;
+import com.passql.member.dto.ChoiceGenerationModeUpdateResponse;
 import com.passql.member.dto.MemberMeResponse;
 import com.passql.member.dto.NicknameChangeRequest;
 import com.passql.member.dto.NicknameChangeResponse;
@@ -52,5 +54,13 @@ public class MemberController implements MemberControllerDocs {
             @AuthMember LoginMember loginMember,
             @Valid @RequestBody NicknameChangeRequest request) {
         return memberService.changeNickname(loginMember.memberUuid(), request);
+    }
+
+    // 선택지 생성 모드 변경 — PRACTICE(재사용) / REAL(항상 새로 생성)
+    @PatchMapping("/me/settings/choice-generation-mode")
+    public ChoiceGenerationModeUpdateResponse updateChoiceGenerationMode(
+            @AuthMember LoginMember loginMember,
+            @Valid @RequestBody ChoiceGenerationModeUpdateRequest request) {
+        return memberService.updateChoiceGenerationMode(loginMember.memberUuid(), request);
     }
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/MemberControllerDocs.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/MemberControllerDocs.java
@@ -3,6 +3,8 @@ package com.passql.web.controller;
 import com.passql.common.dto.Author;
 import com.passql.member.auth.presentation.annotation.AuthMember;
 import com.passql.member.auth.presentation.security.LoginMember;
+import com.passql.member.dto.ChoiceGenerationModeUpdateRequest;
+import com.passql.member.dto.ChoiceGenerationModeUpdateResponse;
 import com.passql.member.dto.MemberMeResponse;
 import com.passql.member.dto.NicknameChangeRequest;
 import com.passql.member.dto.NicknameChangeResponse;
@@ -17,7 +19,7 @@ import kr.suhsaechan.suhapilog.annotation.ApiLogs;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "Member", description = "회원 조회 / 닉네임 재생성 / 닉네임 직접 변경")
+@Tag(name = "Member", description = "회원 조회 / 닉네임 재생성 / 닉네임 직접 변경 / 선택지 생성 모드 변경")
 public interface MemberControllerDocs {
 
   @ApiLogs({
@@ -104,4 +106,27 @@ public interface MemberControllerDocs {
           """
   )
   NicknameChangeResponse changeNickname(@AuthMember LoginMember loginMember, @Valid @RequestBody NicknameChangeRequest request);
+
+  @ApiLogs({
+      @ApiLog(date = "2026.04.27", author = Author.SUHSAECHAN, issueNumber = 313, description = "선택지 생성 모드 변경 API 추가"),
+  })
+  @Operation(
+      summary = "선택지 생성 모드 변경",
+      description = """
+          ## 인증(JWT): **필요**
+
+          ## 요청 바디 (ChoiceGenerationModeUpdateRequest)
+          - **`choiceGenerationMode`**: PRACTICE(재사용) / REAL(항상 새로 생성)
+
+          ## 반환값 (ChoiceGenerationModeUpdateResponse)
+          - **`choiceGenerationMode`**: 변경된 모드
+
+          ## 설명
+          - PRACTICE: 기존 검증된 선택지 재사용 우선 (없을 때만 AI 실시간 생성)
+          - REAL: 기존 선택지 유무와 무관하게 항상 AI 실시간 생성
+          """
+  )
+  ChoiceGenerationModeUpdateResponse updateChoiceGenerationMode(
+      @AuthMember LoginMember loginMember,
+      @Valid @RequestBody ChoiceGenerationModeUpdateRequest request);
 }

--- a/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionController.java
+++ b/server/PQL-Web/src/main/java/com/passql/web/controller/QuestionController.java
@@ -8,6 +8,8 @@ import com.passql.common.exception.CustomException;
 import com.passql.common.exception.constant.ErrorCode;
 import com.passql.member.auth.presentation.annotation.AuthMember;
 import com.passql.member.auth.presentation.security.LoginMember;
+import com.passql.member.constant.ChoiceGenerationMode;
+import com.passql.member.service.MemberService;
 import com.passql.question.dto.ChoiceSetGenerateResponse;
 import com.passql.question.dto.ExecuteResult;
 import com.passql.question.dto.QuestionDetail;
@@ -54,6 +56,7 @@ public class QuestionController implements QuestionControllerDocs {
     private final ChoiceSetResolver choiceSetResolver;
     private final QuestionChoiceSetItemRepository choiceSetItemRepository;
     private final ObjectMapper objectMapper;
+    private final MemberService memberService;
 
     @GetMapping
     public ResponseEntity<Page<QuestionSummary>> getQuestions(
@@ -121,8 +124,9 @@ public class QuestionController implements QuestionControllerDocs {
                         .data(objectMapper.writeValueAsString(
                                 new SseStatusEvent("generating", "선택지 생성 중..."))));
 
-                // ChoiceSetResolver: 프리페치 캐시 히트 → 없으면 실시간 AI 생성
-                QuestionChoiceSet choiceSet = choiceSetResolver.resolveForUser(questionUuid, memberUuid);
+                // ChoiceSetResolver: 모드 조회 후 프리페치 캐시 히트 → 없으면 실시간 AI 생성
+                ChoiceGenerationMode mode = memberService.getChoiceGenerationMode(memberUuid);
+                QuestionChoiceSet choiceSet = choiceSetResolver.resolveForUser(questionUuid, memberUuid, mode);
                 log.info("[generate-choices] resolveForUser 완료: questionUuid={}, choiceSetUuid={}",
                         questionUuid, choiceSet.getChoiceSetUuid());
 

--- a/server/PQL-Web/src/main/resources/db/migration/V0_0_95__add_choice_generation_mode_to_member.sql
+++ b/server/PQL-Web/src/main/resources/db/migration/V0_0_95__add_choice_generation_mode_to_member.sql
@@ -1,3 +1,3 @@
 -- V0_0_95__add_choice_generation_mode_to_member.sql
 ALTER TABLE member
-    ADD COLUMN choice_generation_mode VARCHAR(20) NOT NULL DEFAULT 'PRACTICE';
+    ADD COLUMN IF NOT EXISTS choice_generation_mode VARCHAR(20) NOT NULL DEFAULT 'PRACTICE';

--- a/server/PQL-Web/src/main/resources/db/migration/V0_0_95__add_choice_generation_mode_to_member.sql
+++ b/server/PQL-Web/src/main/resources/db/migration/V0_0_95__add_choice_generation_mode_to_member.sql
@@ -1,0 +1,3 @@
+-- V0_0_95__add_choice_generation_mode_to_member.sql
+ALTER TABLE member
+    ADD COLUMN choice_generation_mode VARCHAR(20) NOT NULL DEFAULT 'PRACTICE';


### PR DESCRIPTION
## Summary

- 설정 페이지에 **문제풀이 섹션**을 신설하고 연습/실전 모드 배지 탭 UI 추가
- **연습 모드**: DB에 검증된 선택지(`status=OK`)가 있으면 재사용 → AI 생성 대기 최소화
- **실전 모드**: 항상 새 선택지를 AI로 생성
- `member` 테이블에 `choice_generation_mode` 컬럼 추가 (기본값 `PRACTICE`)
- `PATCH /api/members/me/settings/choice-generation-mode` API 추가
- `ChoiceSetResolver`의 `MemberRepository` 직접 의존 제거 → 호출자가 모드를 조회해 파라미터로 전달하는 구조로 개선
- `markConsumed`의 self-invocation @Transactional 문제 → Repository `@Modifying @Query`로 해결

## 변경 파일

### 백엔드
- `db/migration/V0_0_95__add_choice_generation_mode_to_member.sql`
- `ChoiceGenerationMode.java` (enum 신규)
- `Member.java` — `choiceGenerationMode` 필드 추가
- `MemberMeResponse.java` — `choiceGenerationMode` 포함
- `ChoiceGenerationModeUpdateRequest/Response.java` (DTO 신규)
- `MemberService.java` — `getChoiceGenerationMode`, `updateChoiceGenerationMode` 추가
- `MemberController.java` — `PATCH /me/settings/choice-generation-mode`
- `QuestionChoiceSetRepository.java` — 연습 모드 재사용 쿼리, `markConsumed` JPQL 추가
- `ChoiceSetResolver.java` — 모드 분기 로직, MemberRepository 의존 제거
- `QuestionController.java`, `QuizSessionService.java` — 모드 조회 후 resolver에 전달

### 클라이언트
- `types/api.ts` — `ChoiceGenerationMode` 타입, `MemberMeResponse` 필드 추가
- `api/members.ts` — `updateChoiceGenerationMode` 함수
- `hooks/useMember.ts` — `useUpdateChoiceGenerationMode` 훅
- `pages/Settings.tsx` — 문제풀이 섹션 + 배지 탭 UI

## Test plan

- [ ] 설정 페이지 > 문제풀이 섹션 > 연습/실전 탭 전환 확인
- [ ] 탭 변경 후 새로고침 시 선택값 유지 확인 (서버 저장)
- [ ] 연습 모드: 동일 문제 두 번째 진입 시 선택지 즉시 표시 확인
- [ ] 실전 모드: 항상 AI 생성 로딩 표시 확인
- [ ] DB `choice_generation_mode` 컬럼 기존 회원에 `PRACTICE` 기본값 확인

Closes #313